### PR TITLE
Standalone example needs 'bundler/setup' to run

### DIFF
--- a/examples/standalone/run.rb
+++ b/examples/standalone/run.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require_relative 'system/container'
 
 App.finalize!


### PR DESCRIPTION
Running the standalone example results in an error:
`cannot load such file -- dry/system/container (LoadError)`

This PR adds the necessary require statement to get the bundler environment up and running.