### PR TITLE
Fix silent failures on undefined methods or variables (#29)

### DIFF
--- a/lib/dry/system/lifecycle.rb
+++ b/lib/dry/system/lifecycle.rb
@@ -97,6 +97,8 @@ module Dry
           container[meth]
         elsif ::Kernel.respond_to?(meth)
           ::Kernel.public_send(meth, *args, &block)
+        else
+          super
         end
       end
     end

--- a/spec/unit/container/finalize_spec.rb
+++ b/spec/unit/container/finalize_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Dry::System::Container, '.finalize' do
     expect(db).to have_received(:load)
   end
 
+  specify 'boot! raises error on undefined method or variable' do
+    expect {
+      system.finalize(:db) { oops('arg') }
+      system.booter.boot!(:db)
+    }.to raise_error(NoMethodError, /oops/)
+
+    expect {
+      system.finalize(:db) { oops }
+      system.booter.boot!(:db)
+    }.to raise_error(NameError, /oops/)
+  end
+
   specify 'booter returns cached lifecycle objects' do
     expect(system.booter.(:db)).to be(system.booter.(:db))
   end


### PR DESCRIPTION
@solnic I couldn't improve/simplify the spec examples you [suggested](https://github.com/dry-rb/dry-system/issues/29#issuecomment-241490760). More specifically, I intended to extract the finalization and boot code and DRY things up a bit. However, this would require additional helper method(s) and that seemed like an overkill to me.
Also, I hope the example description is good.

BTW, I believe`spec/fixtures/test/log/test.log` should be ignored, right?