### PR TITLE
Require names to be provided when importing other system containers

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -95,7 +95,6 @@ module Dry
       # @example
       #   class MyApp < Dry::System::Container
       #     configure do |config|
-      #       config.name = :my_app
       #       config.root = Pathname('/my/app')
       #     end
       #

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -104,7 +104,6 @@ module Dry
         #   class Core < Dry::System::Container
         #     configure do |config|
         #       config.root = Pathname("/path/to/app")
-        #       config.name = :core
         #       config.auto_register = %w(lib/apis lib/core)
         #     end
         #   end
@@ -115,14 +114,13 @@ module Dry
         #   class MyApp < Dry::System::Container
         #     configure do |config|
         #       config.root = Pathname("/path/to/app")
-        #       config.name = :core
         #       config.auto_register = %w(lib/apis lib/core)
         #     end
         #
         #     import core: Core
         #   end
         #
-        # @param other [Hash,Dry::Container::Namespace,Dry::System::Container]
+        # @param other [Hash,Dry::Container::Namespace]
         #
         # @api public
         def import(other)
@@ -130,9 +128,7 @@ module Dry
           when Hash then importer.register(other)
           when Dry::Container::Namespace then super
           else
-            if other < System::Container
-              importer.register(other.config.name => other)
-            end
+            raise ArgumentError, "+other+ must be a hash of names and systems, or a Dry::Container namespace"
           end
         end
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -39,7 +39,6 @@ module Dry
     #
     # Every container needs to be configured with following settings:
     #
-    # * `:name` - a unique container identifier
     # * `:root` - a system root directory (defaults to `pwd`)
     # * `:system_dir` - directory name relative to root, where bootable components
     #                 can be defined in `boot` dir this defaults to `system`
@@ -47,8 +46,6 @@ module Dry
     # @example
     #   class MyApp < Dry::System::Container
     #     configure do |config|
-    #       config.name = :my_app
-    #
     #       # this will auto-register classes from 'lib/components'. ie if you add
     #       # `lib/components/repo.rb` which defines `Repo` class, then it's
     #       # instance will be automatically available as `MyApp['repo']`
@@ -64,7 +61,6 @@ module Dry
       extend Dry::Configurable
       extend Dry::Container::Mixin
 
-      setting :name
       setting :default_namespace
       setting :root, Pathname.pwd.freeze
       setting :system_dir, 'system'.freeze
@@ -83,7 +79,6 @@ module Dry
         #   class MyApp < Dry::System::Container
         #     configure do |config|
         #       config.root = Pathname("/path/to/app")
-        #       config.name = :my_app
         #       config.auto_register = %w(lib/apis lib/core)
         #     end
         #   end
@@ -143,7 +138,6 @@ module Dry
         #   class MyApp < Dry::System::Container
         #     configure do |config|
         #       config.root = Pathname("/path/to/app")
-        #       config.name = :core
         #       config.auto_register = %w(lib/apis lib/core)
         #     end
         #
@@ -222,7 +216,6 @@ module Dry
         #   class MyApp < Dry::System::Container
         #     configure do |config|
         #       config.root = Pathname("/path/to/app")
-        #       config.name = :my_app
         #       config.auto_register = %w(lib/apis lib/core)
         #     end
         #   end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Lazy-booting external deps' do
 
     before do
       module Test
-        Umbrella.import(App)
+        Umbrella.import(main: App)
         Import = Umbrella.injector
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe 'Lazy-booting external deps' do
 
     before do
       module Test
-        App.import(Umbrella)
+        App.import(core: Umbrella)
         Import = App.injector
       end
     end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -3,15 +3,11 @@ RSpec.describe 'Lazy-booting external deps' do
     module Test
       class Umbrella < Dry::System::Container
         configure do |config|
-          config.name = :core
           config.root = SPEC_ROOT.join('fixtures/umbrella').realpath
         end
       end
 
       class App < Dry::System::Container
-        configure do |config|
-          config.name = :main
-        end
       end
     end
   end

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -9,31 +9,14 @@ RSpec.describe Dry::System::Container, '.import' do
     end
   end
 
-  shared_examples_for 'an extended container' do
-    it 'imports one container into another' do
-      expect(app.key?('persistence.users')).to be(false)
+  it 'imports one container into another' do
+    app.import(persistence: db)
 
-      app.finalize!
+    expect(app.key?('persistence.users')).to be(false)
 
-      expect(app['persistence.users']).to eql(%w(jane joe))
-    end
-  end
+    app.finalize!
 
-  context 'when a container has a name' do
-    before do
-      db.configure { |c| c.name = :persistence }
-      app.import(db)
-    end
-
-    it_behaves_like 'an extended container'
-  end
-
-  context 'when container does not have a name' do
-    before do
-      app.import(persistence: db)
-    end
-
-    it_behaves_like 'an extended container'
+    expect(app['persistence.users']).to eql(%w(jane joe))
   end
 
   describe 'import module' do

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -183,16 +183,14 @@ RSpec.describe Dry::System::Container do
 
     it 'passes container to the finalizer block' do
       class Test::Container < Dry::System::Container
-        configure { |c| c.name = :awesome }
-
         finalize(:foo) do |container|
-          register(:w00t, container.config.name)
+          register(:w00t, container.name)
         end
       end
 
       Test::Container.booter.(:foo)
 
-      expect(Test::Container[:w00t]).to be(:awesome)
+      expect(Test::Container[:w00t]).to eql("Test::Container")
     end
   end
 end


### PR DESCRIPTION
As discussed with @solnic in gitter about 100 years ago, we decided that having implicit names for imported containers wasn't a good idea. This change makes it so `Dry::System::Container.import` requires you to pass a hash of names/containers.

After making this change, the `name` setting for `Container` wasn't used anywhere, so I removed this too.