### PR TITLE
Establish concept of manual registrations in Container (and support lazy loading)

### DIFF
--- a/lib/dry/system/constants.rb
+++ b/lib/dry/system/constants.rb
@@ -1,6 +1,7 @@
 module Dry
   module System
     RB_EXT = '.rb'.freeze
+    RB_GLOB = '*.rb'.freeze
     EMPTY_STRING = ''.freeze
     PATH_SEPARATOR = '/'.freeze
     DEFAULT_SEPARATOR = '.'.freeze

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -8,6 +8,7 @@ require 'dry/system/errors'
 require 'dry/system/loader'
 require 'dry/system/booter'
 require 'dry/system/auto_registrar'
+require 'dry/system/manual_registrar'
 require 'dry/system/importer'
 require 'dry/system/component'
 require 'dry/system/constants'
@@ -67,10 +68,12 @@ module Dry
       setting :default_namespace
       setting :root, Pathname.pwd.freeze
       setting :system_dir, 'system'.freeze
+      setting :registrations_dir, 'container'.freeze
       setting :auto_register, []
       setting :loader, Dry::System::Loader
       setting :booter, Dry::System::Booter
       setting :auto_registrar, Dry::System::AutoRegistrar
+      setting :manual_registrar, Dry::System::ManualRegistrar
       setting :importer, Dry::System::Importer
 
       class << self
@@ -247,6 +250,7 @@ module Dry
 
           importer.finalize!
           booter.finalize!
+          manual_registrar.finalize!
           auto_registrar.finalize!
 
           freeze
@@ -309,6 +313,12 @@ module Dry
             load_paths << path
             $LOAD_PATH.unshift(path.to_s)
           end
+          self
+        end
+
+        # @api public
+        def load_registrations!(name)
+          manual_registrar.(name)
           self
         end
 
@@ -436,6 +446,11 @@ module Dry
         end
 
         # @api private
+        def manual_registrar
+          @manual_registrar ||= config.manual_registrar.new(self)
+        end
+
+        # @api private
         def importer
           @importer ||= config.importer.new(self)
         end
@@ -492,6 +507,8 @@ module Dry
             end
           elsif !fallback
             load_local_component(component.prepend(config.default_namespace), true)
+          elsif manual_registrar.file_exists?(component)
+            manual_registrar.(component)
           else
             raise ComponentLoadError, component
           end

--- a/lib/dry/system/manual_registrar.rb
+++ b/lib/dry/system/manual_registrar.rb
@@ -1,0 +1,57 @@
+require 'pathname'
+require 'dry/system/constants'
+
+module Dry
+  module System
+    # Default manual registration implementation
+    #
+    # This is currently configured by default for every System::Container.
+    # Manual registrar objects are responsible for loading files from configured
+    # manual registration paths, which should hold code to explicitly register
+    # certain objects with the container.
+    #
+    # @api private
+    class ManualRegistrar
+      attr_reader :container
+
+      attr_reader :config
+
+      def initialize(container)
+        @container = container
+        @config = container.config
+      end
+
+      # @api private
+      def finalize!
+        Dir[registrations_dir.join(RB_GLOB)].each do |file|
+          call(File.basename(file, RB_EXT))
+        end
+      end
+
+      # @api private
+      def call(name)
+        name = name.respond_to?(:root_key) ? name.root_key.to_s : name
+
+        require(root.join(config.registrations_dir, name))
+      end
+
+      def file_exists?(name)
+        name = name.respond_to?(:root_key) ? name.root_key.to_s : name
+
+        File.exist?(File.join(registrations_dir, "#{name}#{RB_EXT}"))
+      end
+
+      private
+
+      # @api private
+      def registrations_dir
+        root.join(config.registrations_dir)
+      end
+
+      # @api private
+      def root
+        Pathname(container.root)
+      end
+    end
+  end
+end

--- a/spec/fixtures/manual_registration/container/foo.rb
+++ b/spec/fixtures/manual_registration/container/foo.rb
@@ -1,0 +1,6 @@
+Test::Container.namespace(:foo) do |container|
+  container.register('special') do
+    require 'test/foo'
+    Test::Foo.new('special')
+  end
+end

--- a/spec/fixtures/manual_registration/lib/test/foo.rb
+++ b/spec/fixtures/manual_registration/lib/test/foo.rb
@@ -1,0 +1,9 @@
+module Test
+  class Foo
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+  end
+end

--- a/spec/integration/container/lazy_loading/manual_registration_spec.rb
+++ b/spec/integration/container/lazy_loading/manual_registration_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe 'Lazy-loading manual registration files' do
+  before do
+    module Test
+      class Container < Dry::System::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join('fixtures/manual_registration').realpath
+        end
+
+        load_paths!('lib')
+      end
+    end
+  end
+
+  it 'loads a manual registration file if the component could not be found' do
+    expect(Test::Container['foo.special']).to be_a(Test::Foo)
+    expect(Test::Container['foo.special'].name).to eq "special"
+  end
+end


### PR DESCRIPTION
This PR makes manual registration files a proper, configurable part of the container setup.

One benefit of this is that we can now attempt to load a matching manual registration file during lazy loading, which, alongside the lazy loading of bootable deps, means there should be no gaps in what kind of things can be lazily loaded during development.

Resolves #33.

@solnic @AMHOL – what do you think? If you're happy with this direction I'll add more tests to ensure everything's covered.

In working through this, I noticed a few structural things I'd like to improve later. I'm not sure if e.g. `Component#bootable?` and `#boot_file?` should exist - it feels like that's the component knowing too much about other parts of the system. Would it be cleaner for this to be provided by something like `Booter#bootable?(component)`? This is the approach I took with `ManualRegistrar#file_exists?`, anyway.