### PR TITLE
Control auto-registration via magic comments

### DIFF
--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -56,11 +56,13 @@ module Dry
         Dir["#{root}/#{dir}/**/*.rb"]
       end
 
+      # @api private
       def relative_path(dir, file_path)
         dir_root = root.join(dir.to_s.split('/')[0])
         file_path.to_s.sub("#{dir_root}/", '').sub(RB_EXT, EMPTY_STRING)
       end
 
+      # @api private
       def file_options(file_name)
         MagicCommentsParser.(file_name)
       end

--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -46,8 +46,8 @@ module Dry
       # @api private
       def components(dir)
         files(dir).
-          map { |file_path| [file_path, file_options(file_path)] }.
-          map { |(file_path, options)| component(relative_path(dir, file_path), **options) }.
+          map { |file_name| [file_name, file_options(file_name)] }.
+          map { |(file_name, options)| component(relative_path(dir, file_name), **options) }.
           reject { |component| key?(component.identifier) }
       end
 
@@ -61,8 +61,8 @@ module Dry
         file_path.to_s.sub("#{dir_root}/", '').sub(RB_EXT, EMPTY_STRING)
       end
 
-      def file_options(file_path)
-        MagicCommentsParser.(file_path)
+      def file_options(file_name)
+        MagicCommentsParser.(file_name)
       end
 
       # @api private

--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -1,4 +1,5 @@
 require 'dry/system/constants'
+require 'dry/system/magic_comments_parser'
 
 module Dry
   module System
@@ -60,19 +61,8 @@ module Dry
         file_path.to_s.sub("#{dir_root}/", '').sub(RB_EXT, EMPTY_STRING)
       end
 
-      VALID_LINE_RE = /^(#.*)?$/
-      MAGIC_COMMENT_RE = /^#\s+(?<name>[A-Za-z_]+):\s+(?<value>.+?)$/
-
       def file_options(file_path)
-        {}.tap do |options|
-          File.foreach(file_path) do |line|
-            break if !line.match?(VALID_LINE_RE)
-
-            if (match = line.match(MAGIC_COMMENT_RE))
-              options[match[:name].to_sym] = match[:value]
-            end
-          end
-        end
+        MagicCommentsParser.(file_path)
       end
 
       # @api private

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -154,7 +154,7 @@ module Dry
 
       # @api private
       def auto_register?
-        !(options[:auto_register] == "false")
+        !!options.fetch(:auto_register) { true }
       end
 
       # @api private

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -153,6 +153,11 @@ module Dry
       end
 
       # @api private
+      def auto_register?
+        !(options[:auto_register] == "false")
+      end
+
+      # @api private
       def root_key
         namespaces.first
       end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -441,12 +441,13 @@ module Dry
         end
 
         # @api private
-        def component(key)
+        def component(key, **options)
           Component.new(
             key,
             loader: config.loader,
             namespace: config.default_namespace,
-            separator: config.namespace_separator
+            separator: config.namespace_separator,
+            **options,
           )
         end
 

--- a/lib/dry/system/magic_comments_parser.rb
+++ b/lib/dry/system/magic_comments_parser.rb
@@ -4,16 +4,27 @@ module Dry
       VALID_LINE_RE = /^(#.*)?$/.freeze
       COMMENT_RE = /^#\s+(?<name>[A-Za-z]{1}[A-Za-z0-9_]+):\s+(?<value>.+?)$/.freeze
 
+      COERCIONS = {
+        'true' => true,
+        'false' => false,
+      }.freeze
+
       def self.call(file_name)
         {}.tap do |options|
           File.foreach(file_name) do |line|
             break unless line =~ VALID_LINE_RE
 
             if (comment = line.match(COMMENT_RE))
-              options[comment[:name].to_sym] = comment[:value]
+              options[comment[:name].to_sym] = coerce(comment[:value])
             end
           end
         end
+      end
+
+      private
+
+      def self.coerce(value)
+        COERCIONS.fetch(value) { value }
       end
     end
   end

--- a/lib/dry/system/magic_comments_parser.rb
+++ b/lib/dry/system/magic_comments_parser.rb
@@ -7,7 +7,7 @@ module Dry
       def self.call(file_name)
         {}.tap do |options|
           File.foreach(file_name) do |line|
-            break if !line.match?(VALID_LINE_RE)
+            break unless line =~ VALID_LINE_RE
 
             if (comment = line.match(COMMENT_RE))
               options[comment[:name].to_sym] = comment[:value]

--- a/lib/dry/system/magic_comments_parser.rb
+++ b/lib/dry/system/magic_comments_parser.rb
@@ -1,0 +1,20 @@
+module Dry
+  module System
+    class MagicCommentsParser
+      VALID_LINE_RE = /^(#.*)?$/.freeze
+      COMMENT_RE = /^#\s+(?<name>[A-Za-z]{1}[A-Za-z0-9_]+):\s+(?<value>.+?)$/.freeze
+
+      def self.call(file_name)
+        {}.tap do |options|
+          File.foreach(file_name) do |line|
+            break if !line.match?(VALID_LINE_RE)
+
+            if (comment = line.match(COMMENT_RE))
+              options[comment[:name].to_sym] = comment[:value]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/components/no_register.rb
+++ b/spec/fixtures/components/no_register.rb
@@ -1,0 +1,4 @@
+# auto_register: false
+
+class NoRegister
+end

--- a/spec/fixtures/magic_comments/comments.rb
+++ b/spec/fixtures/magic_comments/comments.rb
@@ -3,6 +3,8 @@
 # This is a file with a mix of valid and invalid magic comments
 
 # valid_comment: hello
+# true_comment: true
+# false_comment: false
 # comment_123: alpha-numeric and underscores allowed
 # 123_will_not_match: will not match
 # not-using-underscores: value for comment using dashes

--- a/spec/fixtures/magic_comments/comments.rb
+++ b/spec/fixtures/magic_comments/comments.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# This is a file with a mix of valid and invalid magic comments
+
+# valid_comment: hello
+# comment_123: alpha-numeric and underscores allowed
+# 123_will_not_match: will not match
+# not-using-underscores: value for comment using dashes
+
+  # not_at_start_of_line: will not match
+
+module Test
+end
+
+# after_code: will not match

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
     it { expect(Test::Container['foo']).to be_an_instance_of(Foo) }
     it { expect(Test::Container['bar']).to be_an_instance_of(Bar) }
     it { expect(Test::Container['bar.baz']).to be_an_instance_of(Bar::Baz) }
+
+    it "doesn't register files with inline option 'auto_register: false'" do
+      expect(Test::Container.key?('no_register')).to eql false
+    end
   end
 
   context 'with custom registration block' do

--- a/spec/unit/magic_comments_parser_spec.rb
+++ b/spec/unit/magic_comments_parser_spec.rb
@@ -1,0 +1,31 @@
+require 'dry/system/magic_comments_parser'
+
+RSpec.describe Dry::System::MagicCommentsParser, '.call' do
+  let(:file_name) { SPEC_ROOT.join('fixtures/magic_comments/comments.rb') }
+  let(:comments) { described_class.(file_name) }
+
+  it 'makes comment names available as symbols' do
+    expect(comments.key?(:valid_comment)).to eql true
+  end
+
+  it 'finds magic comments after other commented lines or blank lines' do
+    expect(comments[:valid_comment]).to eq 'hello'
+  end
+
+  it 'does not match comments with invalid names' do
+    expect(comments.values).not_to include 'value for comment using dashes'
+  end
+
+  it 'supports comment names with alpha-numeric characters and underscores (numbers not allowed for first character)' do
+    expect(comments[:comment_123]).to eq 'alpha-numeric and underscores allowed'
+    expect(comments.keys).not_to include(:"123_will_not_match")
+  end
+
+  it 'only matches comments at the start of the line' do
+    expect(comments.key?(:not_at_start_of_line)).to eql false
+  end
+
+  it 'does not match any comments after any lines of code' do
+    expect(comments.key?(:after_code)).to eql false
+  end
+end

--- a/spec/unit/magic_comments_parser_spec.rb
+++ b/spec/unit/magic_comments_parser_spec.rb
@@ -28,4 +28,14 @@ RSpec.describe Dry::System::MagicCommentsParser, '.call' do
   it 'does not match any comments after any lines of code' do
     expect(comments.key?(:after_code)).to eql false
   end
+
+  describe 'coercions' do
+    it 'coerces "true" to true' do
+      expect(comments[:true_comment]).to eq true
+    end
+
+    it 'coerces "false" to false' do
+      expect(comments[:false_comment]).to eq false
+    end
+  end
 end


### PR DESCRIPTION
Auto-registration is one of my favourite dry-system features, and our usual practice has been to point it at our entire `lib/` folders and have it auto-register everything.

The problem is, there's a lot of files in there (e.g. entity or value classes) that don't need to be available in the container - those files we `require` directly and then instantiate their classes directly.

Now, it's mostly harmless for dry-system to register these, but it'd be nice if it didn't. We only want useful registrations in our containers.

One option would be to move these files into a totally separate directly structure, one which the auto-registrar doesn't look at, but that's a big disturbance to our file structure due to some implementation detail of dry-system. We don't want the tail to wag the dog.

Another option would be to maintain some kind of blacklist/whitelist of files to auto-register, but this would become laborious to maintain and would most likely get out of sync.

The best option, I think, is allowing the auto-registration behaviour to be specified _right there in the source file:_

```ruby
# auto_register: false

class MyValueObject
  def initialize(attrs)
    # ...
  end
end
```

This PR makes a first pass at enabling this behaviour. It's not polished yet, but it works, and I wanted to put it up here now to see what @solnic and @AMHOL think about this :)

A benefit of this approach the configuration is _right there with the code,_ so it should be fairly obvious what the deal is, and you're much less likely to forget about it.

And the bigger win, IMO, would be that in dry-web apps, most of the stuff that we're currently throwing into the system "core" dirs (e.g. `apps/main/core/main`) could go straight into the `lib/` dir with the rest of that system's ruby source files. The core dirs have wound up being pretty cluttered, mostly I think because that's where we want to tuck special classes that we don't want automatically registered in the container. Keeping everything in `lib/`, like a standard Ruby project, I think will make the structure of dry-web apps much easier to understand for new users.

@solnic – does the place I've integrated this feature seem good to you? Let me know if you have any thoughts, code-wise, and I'll be happy to incorporate them :)