### PR TITLE
Skip auto registration via config

### DIFF
--- a/examples/custom_configuration_auto_register/Gemfile
+++ b/examples/custom_configuration_auto_register/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'dry-system', path: '../..'
+gem 'sequel'
+gem 'sqlite3'

--- a/examples/custom_configuration_auto_register/lib/entities/user.rb
+++ b/examples/custom_configuration_auto_register/lib/entities/user.rb
@@ -1,0 +1,7 @@
+require 'import'
+
+module Entities
+  class User
+    include Import['persistence.db']
+  end
+end

--- a/examples/custom_configuration_auto_register/lib/user_repo.rb
+++ b/examples/custom_configuration_auto_register/lib/user_repo.rb
@@ -1,0 +1,5 @@
+require 'import'
+
+class UserRepo
+  include Import['persistence.db']
+end

--- a/examples/custom_configuration_auto_register/run.rb
+++ b/examples/custom_configuration_auto_register/run.rb
@@ -1,0 +1,8 @@
+require 'bundler/setup'
+require_relative 'system/container'
+
+App.finalize!
+
+user_repo = App['user_repo']
+puts "User has not been loaded" unless App.key?('entities.user')
+puts user_repo.db.inspect

--- a/examples/custom_configuration_auto_register/system/boot/persistence.rb
+++ b/examples/custom_configuration_auto_register/system/boot/persistence.rb
@@ -1,0 +1,13 @@
+App.finalize(:persistence) do |persistence|
+  init do
+    require 'sequel'
+  end
+
+  start do
+    persistence.register('persistence.db', Sequel.connect('sqlite::memory'))
+  end
+
+  stop do
+    db.close_connection
+  end
+end

--- a/examples/custom_configuration_auto_register/system/container.rb
+++ b/examples/custom_configuration_auto_register/system/container.rb
@@ -1,0 +1,16 @@
+require 'dry/system/container'
+
+class App < Dry::System::Container
+  load_paths!('lib', 'system')
+
+  auto_register!('lib') do |config|
+    config.instance do |component|
+      # some custom initialization logic
+      component.instance
+    end
+
+    config.exclude do |component|
+      component.path =~ /entities/
+    end
+  end
+end

--- a/examples/custom_configuration_auto_register/system/import.rb
+++ b/examples/custom_configuration_auto_register/system/import.rb
@@ -1,0 +1,3 @@
+require_relative 'container'
+
+Import = App.injector

--- a/lib/dry/system/auto_registrar/configuration.rb
+++ b/lib/dry/system/auto_registrar/configuration.rb
@@ -1,0 +1,39 @@
+module Dry
+  module System
+    class AutoRegistrar
+      # Default auto_registrar configuration
+      #
+      # This is currently configured by default for every System::Container.
+      # Configuration allows to define custom initializtion logic as well
+      # as exclusion, for each component that is been register by Dry::System
+      # auto-registration.
+      #
+      # @api private
+      class Configuration
+        DEFAULT_INSTANCE = -> component { component.instance }.freeze
+        FALSE_PROC = -> * { false }.freeze
+
+        def self.setting(name)
+          define_method(name) do |&block|
+            ivar = "@#{name}"
+
+            if block
+              instance_variable_set(ivar, block)
+            else
+              instance_variable_get(ivar)
+            end
+          end
+        end
+
+        setting :exclude
+        setting :instance
+
+        # @api private
+        def initialize
+          @instance = DEFAULT_INSTANCE
+          @exclude = FALSE_PROC
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -316,7 +316,8 @@ module Dry
         #
         # Typically you want to configure auto_register directories, and it will
         # work automatically. Use this method in cases where you want to have an
-        # explicit way where some components are auto-registered.
+        # explicit way where some components are auto-registered, or if you want
+        # to exclude some components from been auto-registered
         #
         # @example
         #   class MyApp < Dry::System::Container
@@ -328,15 +329,21 @@ module Dry
         #     auto_register!('lib/core')
         #
         #     # with a dir and a custom registration block
-        #     auto_register!('lib/core') do |component|
-        #       # custom way of initializing a component
+        #     auto_register!('lib/core') do |config|
+        #       config.instance do |component|
+        #         # custom way of initializing a component
+        #       end
+        #
+        #       config.exclude do |component|
+        #         # return true to exclude component from auto-registration
+        #       end
         #     end
         #   end
         #
         # @param [String] dir The dir name relative to the root dir
         #
-        # @yield [Component]
-        # @see [Component]
+        # @yield AutoRegistrar::Configuration
+        # @see AutoRegistrar::Configuration
         #
         # @return [self]
         #

--- a/spec/unit/auto_registrar/configuration_spec.rb
+++ b/spec/unit/auto_registrar/configuration_spec.rb
@@ -1,0 +1,26 @@
+require 'dry/system/auto_registrar/configuration'
+
+RSpec.describe Dry::System::AutoRegistrar::Configuration do
+  subject(:auto_registration_conf) { Dry::System::AutoRegistrar::Configuration.new }
+
+  describe "deafult values" do
+    it "will setup exclude default proc" do
+      expect(subject.exclude.(8)).to eq false
+    end
+
+    it "will setup instance default proc" do
+      component = double("component")
+      expect(component).to receive(:instance)
+      subject.instance.(component)
+    end
+  end
+
+  describe "add custom proc object to configuration" do
+    it "execute proc that was previously save" do
+      proc = Proc.new { |value| value + 1 }
+      subject.instance(&proc)
+      result = subject.instance.(5)
+      expect(result).to eq 6
+    end
+  end
+end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
     end
   end
 
-  context 'with custom registration block' do
+  context 'with custom configuration block' do
     before do
       class Test::Container < Dry::System::Container
         configure do |config|
@@ -33,14 +33,21 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
       end
     end
 
-    it 'yields found components' do
-      Test::Container.auto_register!('components') do |component|
-        component.identifier
+    it 'exclude specific components' do
+      Test::Container.auto_register!('components') do |config|
+        config.instance do |component|
+          component.identifier
+        end
+
+        config.exclude do |component|
+          component.path =~ /bar/
+        end
       end
 
       expect(Test::Container['foo']).to eql('foo')
-      expect(Test::Container['bar']).to eql('bar')
-      expect(Test::Container['bar.baz']).to eql('bar.baz')
+
+      expect(Test::Container.key?('bar')).to eql false
+      expect(Test::Container.key?('bar.baz')).to eql false
     end
   end
 


### PR DESCRIPTION
This implements https://github.com/dry-rb/dry-system/issues/46

@timriley is we mention this add the ability to skip `auto_registration` via configuration.

