### PR TITLE
Raise error when missmatch between boot filename and registered component

### DIFF
--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -66,11 +66,11 @@ module Dry
       def call(name)
         container, finalizer = finalizers[name]
 
-        if finalizer
-          lifecycle = Lifecycle.new(container, &finalizer)
-          yield(lifecycle) if block_given?
-          lifecycle
-        end
+        raise MissmatchBetweenFileAndRegisteredComponents.new(name, registered_booted_keys) unless finalizer
+
+        lifecycle = Lifecycle.new(container, &finalizer)
+        yield(lifecycle) if block_given?
+        lifecycle
       end
 
       # @api private
@@ -80,6 +80,11 @@ module Dry
       end
 
       private
+
+      # @api private
+      def registered_booted_keys
+        finalizers.keys - booted.keys
+      end
 
       # @api private
       def boot_files

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -66,7 +66,7 @@ module Dry
       def call(name)
         container, finalizer = finalizers[name]
 
-        raise MissmatchBetweenFileAndRegisteredComponents.new(name, registered_booted_keys) unless finalizer
+        raise ComponentFileMismatchError.new(name, registered_booted_keys) unless finalizer
 
         lifecycle = Lifecycle.new(container, &finalizer)
         yield(lifecycle) if block_given?

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -10,6 +10,15 @@ module Dry
       end
     end
 
+    # Error raised when booter file do not match with register component
+    #
+    # @api public
+    MissmatchBetweenFileAndRegisteredComponents = Class.new(StandardError) do
+      def initialize(filename, registered_booted_keys)
+        super("Missmatch between filename +#{filename}+ and registered components +#{registered_booted_keys}+")
+      end
+    end
+
     # Error raised when a resolved component couldn't be found
     #
     # @api public

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -13,9 +13,9 @@ module Dry
     # Error raised when booter file do not match with register component
     #
     # @api public
-    MissmatchBetweenFileAndRegisteredComponents = Class.new(StandardError) do
+    ComponentFileMismatchError = Class.new(StandardError) do
       def initialize(filename, registered_booted_keys)
-        super("Missmatch between filename +#{filename}+ and registered components +#{registered_booted_keys}+")
+        super("Mismatch between filename +#{filename}+ and registered components +#{registered_booted_keys}+")
       end
     end
 

--- a/spec/fixtures/other/config/boot/hell.rb
+++ b/spec/fixtures/other/config/boot/hell.rb
@@ -1,0 +1,3 @@
+Test::Container.finalize :heaven do |container|
+  container.register('heaven', 'string')
+end

--- a/spec/fixtures/test/system/boot/hell.rb
+++ b/spec/fixtures/test/system/boot/hell.rb
@@ -1,0 +1,3 @@
+Test::Container.finalize :heaven do |container|
+  container.register('heaven', 'string')
+end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe Dry::System::Container do
         )
       end
 
-      describe "missmatch betwenn finalize name and registerd component" do
-        it "raises MissmatchBetweenFileAndRegisteredComponents" do
+      describe "missmatch betwenn finalize name and registered component" do
+        it "raises a meaningful error" do
           expect{
             container.boot!(:hell)
           }.to raise_error(Dry::System::ComponentFileMismatchError)

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Dry::System::Container do
         it "raises MissmatchBetweenFileAndRegisteredComponents" do
           expect{
             container.boot!(:hell)
-          }.to raise_error(Dry::System::MissmatchBetweenFileAndRegisteredComponents)
+          }.to raise_error(Dry::System::ComponentFileMismatchError)
         end
       end
     end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -142,6 +142,14 @@ RSpec.describe Dry::System::Container do
           'component identifier +foo+ is invalid or boot file is missing'
         )
       end
+
+      describe "missmatch betwenn finalize name and registerd component" do
+        it "raises MissmatchBetweenFileAndRegisteredComponents" do
+          expect{
+            container.boot!(:hell)
+          }.to raise_error(Dry::System::MissmatchBetweenFileAndRegisteredComponents)
+        end
+      end
     end
 
     context 'with the default core dir' do


### PR DESCRIPTION
This solve #38 

@timriley, @solnic  I don't know if you have it in the roadmap or we do not want to raise such error. But I thought to give it a try since it looks quite simple to implement.