### PR TITLE
Require explicitly given names for imported containers

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -104,7 +104,6 @@ module Dry
         #   class Core < Dry::System::Container
         #     configure do |config|
         #       config.root = Pathname("/path/to/app")
-        #       config.name = :core
         #       config.auto_register = %w(lib/apis lib/core)
         #     end
         #   end
@@ -115,14 +114,13 @@ module Dry
         #   class MyApp < Dry::System::Container
         #     configure do |config|
         #       config.root = Pathname("/path/to/app")
-        #       config.name = :core
         #       config.auto_register = %w(lib/apis lib/core)
         #     end
         #
         #     import core: Core
         #   end
         #
-        # @param other [Hash,Dry::Container::Namespace,Dry::System::Container]
+        # @param other [Hash,Dry::Container::Namespace]
         #
         # @api public
         def import(other)
@@ -130,9 +128,7 @@ module Dry
           when Hash then importer.register(other)
           when Dry::Container::Namespace then super
           else
-            if other < System::Container
-              importer.register(other.config.name => other)
-            end
+            raise ArgumentError, "+other+ must be a hash of names and systems, or a Dry::Container namespace"
           end
         end
 

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Lazy-booting external deps' do
 
     before do
       module Test
-        Umbrella.import(App)
+        Umbrella.import(main: App)
         Import = Umbrella.injector
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe 'Lazy-booting external deps' do
 
     before do
       module Test
-        App.import(Umbrella)
+        App.import(core: Umbrella)
         Import = App.injector
       end
     end

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -9,31 +9,14 @@ RSpec.describe Dry::System::Container, '.import' do
     end
   end
 
-  shared_examples_for 'an extended container' do
-    it 'imports one container into another' do
-      expect(app.key?('persistence.users')).to be(false)
+  it 'imports one container into another' do
+    app.import(persistence: db)
 
-      app.finalize!
+    expect(app.key?('persistence.users')).to be(false)
 
-      expect(app['persistence.users']).to eql(%w(jane joe))
-    end
-  end
+    app.finalize!
 
-  context 'when a container has a name' do
-    before do
-      db.configure { |c| c.name = :persistence }
-      app.import(db)
-    end
-
-    it_behaves_like 'an extended container'
-  end
-
-  context 'when container does not have a name' do
-    before do
-      app.import(persistence: db)
-    end
-
-    it_behaves_like 'an extended container'
+    expect(app['persistence.users']).to eql(%w(jane joe))
   end
 
   describe 'import module' do


### PR DESCRIPTION
This PR makes it so that `Dry::System::Container.import` requires you to pass a hash of names and containers, instead of supporting containers on their own and using their configured names implicitly.

The rationale for this is that when you're importing one container into another, you should be making a clear decision about the local name to use for that imported container. This isn't much extra work at all, but makes for a lot of extra clarity around the behavior of the imported containers.