### PR TITLE
Allow default_namespace to declare multilevel directories

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -47,9 +47,7 @@ module Dry
           options = DEFAULT_OPTIONS.merge(options || {})
 
           ns, sep = options.values_at(:namespace, :separator)
-
-          ns_name = ensure_valid_namespace(ns, sep)
-          identifier = ensure_valid_identifier(name, ns_name, sep)
+          identifier = ensure_valid_identifier(name, ns, sep)
 
           path = name.to_s.gsub(sep, PATH_SEPARATOR)
           loader = options.fetch(:loader, Loader).new(path)
@@ -59,21 +57,14 @@ module Dry
       end
 
       # @api private
-      def self.ensure_valid_namespace(ns, sep)
-        ns_name = ns.to_s
-        raise InvalidNamespaceError, ns_name if ns && ns_name.include?(sep)
-        ns_name
-      end
-
-      # @api private
-      def self.ensure_valid_identifier(name, ns_name, sep)
+      def self.ensure_valid_identifier(name, ns, sep)
         keys = name.to_s.scan(WORD_REGEX)
 
         if keys.uniq.size != keys.size
           raise InvalidComponentError, name, 'duplicated keys in the name'
         end
 
-        keys.reject { |s| ns_name == s }.join(sep)
+        keys.reject { |s| ns.to_s.include?(s) }.join(sep)
       end
 
       # @api private

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -28,15 +28,6 @@ module Dry
       end
     end
 
-    # Error raised when invalid namespace name was provided
-    #
-    # @api public
-    InvalidNamespaceError = Class.new(StandardError) do
-      def initialize(ns)
-        super("Namespace #{ns} cannot include a separator")
-      end
-    end
-
     # Error raised when resolved component couldn't be loaded
     #
     # @api public

--- a/spec/fixtures/multiple_namespaced_components/multiple/level/baz.rb
+++ b/spec/fixtures/multiple_namespaced_components/multiple/level/baz.rb
@@ -1,0 +1,7 @@
+module Multiple
+  module Level
+    class Baz
+      include Test::Container.injector["foz"]
+    end
+  end
+end

--- a/spec/fixtures/multiple_namespaced_components/multiple/level/foz.rb
+++ b/spec/fixtures/multiple_namespaced_components/multiple/level/foz.rb
@@ -1,0 +1,6 @@
+module Multiple
+  module Level
+    class Foz
+    end
+  end
+end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe Dry::System::Component do
       expect(create.()).to be(create.())
     end
 
-    it 'raises when namespace includes a separator' do
-      expect { Dry::System::Component.new('foo.bar.baz', namespace: 'foo.bar') }
-        .to raise_error(Dry::System::InvalidNamespaceError, /foo\.bar/)
-    end
-
     it 'raises when identifier/path has duplicated keys' do
       expect { Dry::System::Component.new('foo.bar.foo', namespace: 'foo') }
         .to raise_error(Dry::System::InvalidComponentError, /foo\.bar\.foo/)

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -69,6 +69,23 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
     specify { expect(Test::Container['foo']).to be_a(Namespaced::Foo) }
   end
 
+  context 'standard loader with a default namespace with multiple level' do
+    before do
+      class Test::Container < Dry::System::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join('fixtures').realpath
+          config.default_namespace = 'multiple.level'
+        end
+
+        load_paths!('multiple_namespaced_components')
+        auto_register!('multiple_namespaced_components')
+      end
+    end
+
+    specify { expect(Test::Container['baz']).to be_a(Multiple::Level::Baz) }
+    specify { expect(Test::Container['foz']).to be_a(Multiple::Level::Foz) }
+  end
+
   context 'with a custom loader' do
     before do
       class Test::Loader < Dry::System::Loader


### PR DESCRIPTION
Solves #40 

Remove unused Error class and tweak `ensure_valid_identifier ` to allow multilevel directories