### PR TITLE
Added enabled_stubs! for testing finalize! containers

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -239,7 +239,7 @@ module Dry
         # @return [self] frozen container
         #
         # @api public
-        def finalize!(&block)
+        def finalize!(freezable: true, &block)
           return self if frozen?
 
           yield(self) if block
@@ -249,7 +249,7 @@ module Dry
           manual_registrar.finalize!
           auto_registrar.finalize!
 
-          freeze
+          freeze if freezable
         end
 
         # Boots a specific component

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -239,7 +239,7 @@ module Dry
         # @return [self] frozen container
         #
         # @api public
-        def finalize!(freezable: true, &block)
+        def finalize!(freeze: true, &block)
           return self if frozen?
 
           yield(self) if block
@@ -249,7 +249,7 @@ module Dry
           manual_registrar.finalize!
           auto_registrar.finalize!
 
-          freeze if freezable
+          self.freeze if freeze
         end
 
         # Boots a specific component

--- a/lib/dry/system/stub.rb
+++ b/lib/dry/system/stub.rb
@@ -1,0 +1,27 @@
+module Dry
+  module System
+    class Container
+      # Incuded only in the Test environment
+      # Sending the message enabled_stubs! allow you to stub finalize container
+      # in your tests.
+      #
+      # @api private
+      module Stub
+        def finalize!(&block)
+          yield(self) if block
+
+          importer.finalize!
+          booter.finalize!
+          manual_registrar.finalize!
+          auto_registrar.finalize!
+        end
+      end
+
+      class << self
+        def enabled_stubs!
+          extend ::Dry::System::Container::Stub
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/stub.rb
+++ b/lib/dry/system/stub.rb
@@ -2,8 +2,8 @@ module Dry
   module System
     class Container
       # Incuded only in the Test environment
-      # Sending the message enabled_stubs! allow you to stub finalize container
-      # in your tests.
+      # Sending the message enable_stubs! allow you to stub components after
+      # finalize your container in your tests.
       #
       # @api private
       module Stub
@@ -18,7 +18,7 @@ module Dry
       end
 
       class << self
-        def enabled_stubs!
+        def enable_stubs!
           extend ::Dry::System::Container::Stub
         end
       end

--- a/lib/dry/system/stubs.rb
+++ b/lib/dry/system/stubs.rb
@@ -6,7 +6,7 @@ module Dry
       # finalize your container in your tests.
       #
       # @api private
-      module Stub
+      module Stubs
         def finalize!(&block)
           yield(self) if block
 
@@ -19,7 +19,7 @@ module Dry
 
       class << self
         def enable_stubs!
-          extend ::Dry::System::Container::Stub
+          extend ::Dry::System::Container::Stubs
         end
       end
     end

--- a/lib/dry/system/stubs.rb
+++ b/lib/dry/system/stubs.rb
@@ -8,12 +8,7 @@ module Dry
       # @api private
       module Stubs
         def finalize!(&block)
-          yield(self) if block
-
-          importer.finalize!
-          booter.finalize!
-          manual_registrar.finalize!
-          auto_registrar.finalize!
+          super(freezable: false, &block)
         end
       end
 

--- a/lib/dry/system/stubs.rb
+++ b/lib/dry/system/stubs.rb
@@ -12,10 +12,8 @@ module Dry
         end
       end
 
-      class << self
-        def enable_stubs!
-          extend ::Dry::System::Container::Stubs
-        end
+      def self.enable_stubs!
+        extend ::Dry::System::Container::Stubs
       end
     end
   end

--- a/lib/dry/system/stubs.rb
+++ b/lib/dry/system/stubs.rb
@@ -8,7 +8,7 @@ module Dry
       # @api private
       module Stubs
         def finalize!(&block)
-          super(freezable: false, &block)
+          super(freeze: false, &block)
         end
       end
 

--- a/spec/fixtures/stubbing/lib/stubbing/car.rb
+++ b/spec/fixtures/stubbing/lib/stubbing/car.rb
@@ -1,0 +1,7 @@
+module Stubbing
+  class Car
+    def wheels_count
+      4
+    end
+  end
+end

--- a/spec/fixtures/stubbing/system/boot/mock.rb
+++ b/spec/fixtures/stubbing/system/boot/mock.rb
@@ -1,0 +1,4 @@
+Test::Container.finalize(:mock) do |container|
+
+  container.register(:mock, false)
+end

--- a/spec/fixtures/stubbing/system/boot/mock.rb
+++ b/spec/fixtures/stubbing/system/boot/mock.rb
@@ -1,4 +1,3 @@
 Test::Container.finalize(:mock) do |container|
-
   container.register(:mock, false)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ Dir[SPEC_ROOT.join('support/*.rb').to_s].each { |f| require f }
 Dir[SPEC_ROOT.join('shared/*.rb').to_s].each { |f| require f }
 
 require 'dry/system/container'
+require 'dry/system/stub'
 
 module TestNamespace
   def remove_constants

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ Dir[SPEC_ROOT.join('support/*.rb').to_s].each { |f| require f }
 Dir[SPEC_ROOT.join('shared/*.rb').to_s].each { |f| require f }
 
 require 'dry/system/container'
-require 'dry/system/stub'
+require 'dry/system/stubs'
 
 module TestNamespace
   def remove_constants

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -207,7 +207,6 @@ RSpec.describe Dry::System::Container do
       end
     end
 
-
     describe 'without enable_stubs!' do
       before do
         container.finalize!
@@ -226,13 +225,13 @@ RSpec.describe Dry::System::Container do
         container.finalize!
       end
 
-      it 'allow to stub the container it self' do
+      it 'allows to stub the container it self' do
         expect(container['mock']).to eq false
         allow(container).to receive(:[]).with('mock').and_return(true)
         expect(container['mock']).to eq true
       end
 
-      it 'allow to stub components' do
+      it 'allows to stub components' do
         car = container['stubbing.car']
         expect(car.wheels_count).to eq 4
         allow(car).to receive(:wheels_count).and_return(5)

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Dry::System::Container do
     end
 
 
-    describe 'without enabled_stubs!' do
+    describe 'without enable_stubs!' do
       before do
         container.finalize!
       end
@@ -220,9 +220,9 @@ RSpec.describe Dry::System::Container do
       end
     end
 
-    describe 'with enabled_stubs!' do
+    describe 'with enable_stubs!' do
       before do
-        container.enabled_stubs!
+        container.enable_stubs!
         container.finalize!
       end
 

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -195,4 +195,49 @@ RSpec.describe Dry::System::Container do
       expect(Test::Container[:w00t]).to be(:awesome)
     end
   end
+
+  context 'Allow to stub container' do
+    before do
+      class Test::Container < Dry::System::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join('fixtures/stubbing').realpath
+        end
+        load_paths!('lib')
+        auto_register!('lib')
+      end
+    end
+
+
+    describe 'without enabled_stubs!' do
+      before do
+        container.finalize!
+      end
+
+      it 'raises error when trying to stub freeze container' do
+        expect {
+          allow(container).to receive(:[]).with('mock').and_return(true)
+        }.to raise_error(RuntimeError, /frozen/)
+      end
+    end
+
+    describe 'with enabled_stubs!' do
+      before do
+        container.enabled_stubs!
+        container.finalize!
+      end
+
+      it 'allow to stub the container it self' do
+        expect(container['mock']).to eq false
+        allow(container).to receive(:[]).with('mock').and_return(true)
+        expect(container['mock']).to eq true
+      end
+
+      it 'allow to stub components' do
+        car = container['stubbing.car']
+        expect(car.wheels_count).to eq 4
+        allow(car).to receive(:wheels_count).and_return(5)
+        expect(car.wheels_count).to eq 5
+      end
+    end
+  end
 end


### PR DESCRIPTION
Solves #49 

After giving some thoughts and looking at how we implement stubbing in `dry-container` I came up with this solution.

There a few things I do not like is that the `finalize!` method in the `Stub` module is practically the same except for the `freeze` part.

I had other implementation where we pass an argument to `finalize!` method making `freeze` control by this arguments.

```ruby
def finalize!(testing: false, &block)
  return self if frozen?

  yield(self) if block

  importer.finalize!
  booter.finalize!
  manual_registrar.finalize!
  auto_registrar.finalize!

  freeze unless testing
end
```

And inside the `Stub` module we can simply.
```ruby
def finalize!(&block)
  super(testing: true, &block)
end
```

Or even in test the user can say `finalize(testing: true)` without the need of the `Stub` module at all

@solnic also point out that we could bring back the `env` setting back to `dry-system`