### PR TITLE
Accept plain string paths for container’s config.root

### DIFF
--- a/dry-system.gemspec
+++ b/dry-system.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-container', '~> 0.6'
   spec.add_runtime_dependency 'dry-auto_inject', '>= 0.4.0'
-  spec.add_runtime_dependency 'dry-configurable', '~> 0.2'
+  spec.add_runtime_dependency 'dry-configurable', '~> 0.7', '>= 0.7.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -66,7 +66,7 @@ module Dry
 
       setting :name
       setting :default_namespace
-      setting :root, Pathname.pwd.freeze
+      setting(:root, Pathname.pwd.freeze) { |path| Pathname(path) }
       setting :system_dir, 'system'.freeze
       setting :registrations_dir, 'container'.freeze
       setting :auto_register, []

--- a/lib/dry/system/manual_registrar.rb
+++ b/lib/dry/system/manual_registrar.rb
@@ -1,4 +1,3 @@
-require 'pathname'
 require 'dry/system/constants'
 
 module Dry
@@ -50,7 +49,7 @@ module Dry
 
       # @api private
       def root
-        Pathname(container.root)
+        container.root
       end
     end
   end

--- a/spec/unit/container/config_spec.rb
+++ b/spec/unit/container/config_spec.rb
@@ -1,0 +1,38 @@
+require 'dry/system/container'
+
+RSpec.describe Dry::System::Container, '.config' do
+  subject(:config) { Test::Container.config }
+  let(:configuration) { proc { } }
+
+  before do
+    class Test::Container < Dry::System::Container
+    end
+    Test::Container.configure(&configuration)
+  end
+
+  describe '#root' do
+    subject(:root) { config.root }
+
+    context 'no value' do
+      it 'defaults to pwd' do
+        expect(root).to eq Pathname.pwd
+      end
+    end
+
+    context 'string provided' do
+      let(:configuration) { proc { |config| config.root = '/tmp' } }
+
+      it 'coerces string paths to pathname' do
+        expect(root).to eq Pathname('/tmp')
+      end
+    end
+
+    context 'pathname provided' do
+      let(:configuration) { proc { |config| config.root = Pathname('/tmp') } }
+
+      it 'accepts the pathname' do
+        expect(root).to eq Pathname('/tmp')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is helpful because new users may reasonably provide a string value for this config and we shouldn't give them an error in return for this.