### PR TITLE
3rd party bootable components

### DIFF
--- a/lib/dry/system.rb
+++ b/lib/dry/system.rb
@@ -1,4 +1,27 @@
+require 'dry/system/provider'
+require 'dry/system/provider_registry'
+
 module Dry
   module System
+    # Register external component provider
+    #
+    # @api public
+    def self.register_provider(identifier, options)
+      providers.register(identifier, options)
+      self
+    end
+
+    # Register an external component that can be booted within other systems
+    #
+    # @api public
+    def self.register_component(identifier, provider:, &block)
+      providers[provider].register_component(identifier, block)
+      self
+    end
+
+    # @api private
+    def self.providers
+      @__providers__ ||= ProviderRegistry.new
+    end
   end
 end

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -1,3 +1,4 @@
+require 'dry/system/components/bootable'
 require 'dry/system/errors'
 require 'dry/system/lifecycle'
 
@@ -11,95 +12,189 @@ module Dry
     #
     # @api private
     class Booter
+      class LifecycleContainer
+        include Container::Mixin
+      end
+
       attr_reader :path
 
-      attr_reader :finalizers
-
       attr_reader :booted
+
+      attr_reader :components
+
+      attr_reader :listeners
+
+      class ComponentRegistry
+        include Enumerable
+
+        attr_reader :components
+
+        def initialize
+          @components = []
+        end
+
+        def each(&block)
+          components.each(&block)
+        end
+
+        def register(component)
+          @components << component
+        end
+
+        def exists?(name)
+          components.any? { |component| component.identifier == name }
+        end
+
+        def [](name)
+          component = components.detect { |component| component.identifier == name }
+
+          if component
+            component.ensure_valid_boot_file
+            component
+          else
+            raise InvalidComponentIdentifierError, name
+          end
+        end
+      end
 
       # @api private
       def initialize(path)
         @path = path
-        @booted = {}
-        @finalizers = {}
+        @booted = []
+        @components = ComponentRegistry.new
+        @listeners = Hash.new { |h, k| h[k] = {} }
       end
 
       # @api private
-      def []=(name, fn)
-        @finalizers[name] = fn
+      def register_component(*args)
+        if args.size > 1
+          name, container, opts, fn = args
+          components.register(Components::Bootable.new(name, fn, opts.merge(container: container)))
+        else
+          components.register(args[0])
+        end
+
+        self
+      end
+
+      # @api private
+      def load_component(path)
+        identifier = Pathname(path).basename('.rb').to_s.to_sym
+
+        unless components.exists?(identifier)
+          require path
+        end
+
         self
       end
 
       # @api private
       def finalize!
-        Dir[boot_files].each do |path|
-          start(File.basename(path, '.rb').to_sym)
+        boot_files.each do |path|
+          load_component(path)
+        end
+
+        components.each do |component|
+          start(component)
         end
         freeze
       end
 
       # @api private
-      def init(name)
-        Kernel.require(path.join(name.to_s))
+      def init(name_or_component)
+        with_component(name_or_component) do |component|
+          call(component) do |lifecycle, container|
+            lifecycle.(:init)
 
-        call(name) do |lifecycle|
-          lifecycle.(:init)
-          yield(lifecycle) if block_given?
+            if listener = listeners[component.key][:init]
+              listener.()
+            end
+
+            yield(lifecycle, container) if block_given?
+          end
+
+          self
         end
+      end
+
+      # @api private
+      def start(name_or_component)
+        with_component(name_or_component) do |component|
+          return self if booted.include?(component)
+
+          init(name_or_component) do |lifecycle, container|
+            lifecycle.(:start)
+
+            if lifecycle.container != container
+              container.register(component.key, lifecycle.container[component.identifier])
+            end
+          end
+
+          booted << component
+
+          self
+        end
+      end
+
+      # @api private
+      def call(name_or_component)
+        with_component(name_or_component) do |component|
+          lf_container = component.external? ? lifecycle_container : component.container
+
+          unless component
+            raise ComponentFileMismatchError.new(name, registered_booted_keys)
+          end
+
+          lifecycle = Lifecycle.new(lf_container, &component)
+          yield(lifecycle, component.container) if block_given?
+          lifecycle
+        end
+      end
+
+      # @api private
+      def lifecycle_container
+        LifecycleContainer.new
+      end
+
+      # @api private
+      def on(spec, &block)
+        identifier, step = spec.to_a.flatten(1)
+        listeners[identifier][step] = block
 
         self
       end
 
       # @api private
-      def start(name)
-        check_component_identifier(name)
+      def with_component(id_or_component)
+        component =
+          case id_or_component
+          when Symbol
+            require_boot_file(id_or_component) unless components.exists?(id_or_component)
+            components[id_or_component]
+          when Components::Bootable
+            id_or_component
+          end
 
-        return self if booted.key?(name)
+        raise InvalidComponentError, id_or_component unless component
 
-        init(name) { |lifecycle| lifecycle.(:start) }
-        booted[name] = true
-
-        self
+        yield(component)
       end
 
       # @api private
-      def call(name)
-        container, finalizer = finalizers[name]
+      def require_boot_file(identifier)
+        boot_file = boot_files.detect { |path| Pathname(path).basename('.rb').to_s == identifier.to_s }
+        require boot_file if boot_file
+      end
 
-        raise ComponentFileMismatchError.new(name, registered_booted_keys) unless finalizer
-
-        lifecycle = Lifecycle.new(container, &finalizer)
-        yield(lifecycle) if block_given?
-        lifecycle
+      # @api private
+      def boot_files
+        Dir["#{path}/**/*.rb"]
       end
 
       # @api private
       def boot_dependency(component)
         boot_file = component.boot_file(path)
         start(boot_file.basename('.*').to_s.to_sym) if boot_file.exist?
-      end
-
-      private
-
-      # @api private
-      def registered_booted_keys
-        finalizers.keys - booted.keys
-      end
-
-      # @api private
-      def boot_files
-        path.join('**/*.rb').to_s
-      end
-
-      # @api private
-      def check_component_identifier(name)
-        unless name.is_a?(Symbol)
-          raise InvalidComponentIdentifierTypeError, name
-        end
-
-        unless path.join("#{name}.rb").exist?
-          raise InvalidComponentIdentifierError, name
-        end
       end
     end
   end

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -1,6 +1,7 @@
 require 'dry/system/components/bootable'
 require 'dry/system/errors'
 require 'dry/system/lifecycle'
+require 'dry/system/booter/component_registry'
 
 module Dry
   module System
@@ -23,39 +24,6 @@ module Dry
       attr_reader :components
 
       attr_reader :listeners
-
-      class ComponentRegistry
-        include Enumerable
-
-        attr_reader :components
-
-        def initialize
-          @components = []
-        end
-
-        def each(&block)
-          components.each(&block)
-        end
-
-        def register(component)
-          @components << component
-        end
-
-        def exists?(name)
-          components.any? { |component| component.identifier == name }
-        end
-
-        def [](name)
-          component = components.detect { |component| component.identifier == name }
-
-          if component
-            component.ensure_valid_boot_file
-            component
-          else
-            raise InvalidComponentIdentifierError, name
-          end
-        end
-      end
 
       # @api private
       def initialize(path)

--- a/lib/dry/system/booter/component_registry.rb
+++ b/lib/dry/system/booter/component_registry.rb
@@ -1,0 +1,38 @@
+module Dry
+  module System
+    class Booter
+      class ComponentRegistry
+        include Enumerable
+
+        attr_reader :components
+
+        def initialize
+          @components = []
+        end
+
+        def each(&block)
+          components.each(&block)
+        end
+
+        def register(component)
+          @components << component
+        end
+
+        def exists?(name)
+          components.any? { |component| component.identifier == name }
+        end
+
+        def [](name)
+          component = components.detect { |component| component.identifier == name }
+
+          if component
+            component.ensure_valid_boot_file
+            component
+          else
+            raise InvalidComponentIdentifierError, name
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -1,0 +1,56 @@
+module Dry
+  module System
+    module Components
+      class Bootable
+        attr_reader :identifier
+
+        attr_reader :fn
+
+        attr_reader :options
+
+        def initialize(identifier, fn, options = {})
+          @identifier = identifier
+          @fn = fn
+          @options = options
+        end
+
+        def to_proc
+          fn
+        end
+
+        def container
+          options.fetch(:container)
+        end
+
+        def external?
+          false
+        end
+
+        def key
+          options.fetch(:key, identifier)
+        end
+
+        def with(new_options)
+          self.class.new(identifier, fn, options.merge(new_options))
+        end
+
+        def boot_file
+          container_boot_files.
+            detect { |path| Pathname(path).basename('.rb').to_s == identifier.to_s }
+        end
+
+        def boot_path
+          container.boot_path
+        end
+
+        def container_boot_files
+          Dir[container.boot_path.join('**/*.rb')]
+        end
+
+        def ensure_valid_boot_file
+          raise ComponentFileMismatchError, self unless boot_file
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/components/external.rb
+++ b/lib/dry/system/components/external.rb
@@ -1,0 +1,13 @@
+require 'dry/system/components/bootable'
+
+module Dry
+  module System
+    module Components
+      class External < Components::Bootable
+        def external?
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -14,8 +14,8 @@ module Dry
     #
     # @api public
     ComponentFileMismatchError = Class.new(StandardError) do
-      def initialize(filename, registered_booted_keys)
-        super("Mismatch between filename +#{filename}+ and registered components +#{registered_booted_keys}+")
+      def initialize(component)
+        super("Boot file for component #{component.identifier.inspect} not found. Container boot files under #{component.boot_path}: #{component.container_boot_files.inspect}")
       end
     end
 

--- a/lib/dry/system/lifecycle.rb
+++ b/lib/dry/system/lifecycle.rb
@@ -23,9 +23,11 @@ module Dry
 
       attr_reader :triggers
 
+      attr_reader :opts
+
       # @api private
-      def self.new(container, &block)
-        cache.fetch_or_store([container, block].hash) do
+      def self.new(container, opts = {}, &block)
+        cache.fetch_or_store([container, opts, block].hash) do
           super
         end
       end
@@ -36,10 +38,11 @@ module Dry
       end
 
       # @api private
-      def initialize(container, &block)
+      def initialize(container, opts, &block)
         @container = container
         @statuses = []
         @triggers = {}
+        @opts = opts
         instance_exec(container, &block)
       end
 

--- a/lib/dry/system/provider.rb
+++ b/lib/dry/system/provider.rb
@@ -1,0 +1,40 @@
+require 'dry/system/components/external'
+
+module Dry
+  module System
+    class Provider
+      attr_reader :identifier
+
+      attr_reader :options
+
+      attr_reader :components
+
+      def initialize(identifier, options)
+        @identifier = identifier
+        @options = options
+        @components = {}
+      end
+
+      def boot_path
+        options.fetch(:boot_path)
+      end
+
+      def boot_files
+        Dir[boot_path.join('**/*.rb')]
+      end
+
+      def register_component(name, fn)
+        components[name] = Components::External.new(name, fn)
+      end
+
+      def boot_file(name)
+        boot_files.detect { |path| Pathname(path).basename('.rb').to_s == name.to_s }
+      end
+
+      def component(name, options = {})
+        require boot_file(name)
+        components.fetch(name).with(options)
+      end
+    end
+  end
+end

--- a/lib/dry/system/provider_registry.rb
+++ b/lib/dry/system/provider_registry.rb
@@ -1,0 +1,25 @@
+module Dry
+  module System
+    class ProviderRegistry
+      include Enumerable
+
+      attr_reader :providers
+
+      def initialize
+        @providers = []
+      end
+
+      def each(&block)
+        providers.each(&block)
+      end
+
+      def register(identifier, options)
+        providers << Provider.new(identifier, options)
+      end
+
+      def [](identifier)
+        detect { |provider| provider.identifier == identifier }
+      end
+    end
+  end
+end

--- a/spec/fixtures/external_components/alt-components/logger.rb
+++ b/spec/fixtures/external_components/alt-components/logger.rb
@@ -1,0 +1,14 @@
+require "dry/system"
+
+Dry::System.register_component(:logger, provider: :alt) do
+  init do
+    module AltComponents
+      class Logger
+      end
+    end
+  end
+
+  start do
+    register(:logger, AltComponents::Logger.new)
+  end
+end

--- a/spec/fixtures/external_components/components/logger.rb
+++ b/spec/fixtures/external_components/components/logger.rb
@@ -1,0 +1,17 @@
+require "dry/system"
+
+Dry::System.register_component(:logger, provider: :external_components) do
+  init do
+    module ExternalComponents
+      class Logger
+        class << self
+          attr_accessor :default_level
+        end
+      end
+    end
+  end
+
+  start do
+    register(:logger, ExternalComponents::Logger.new)
+  end
+end

--- a/spec/fixtures/external_components/lib/external_components.rb
+++ b/spec/fixtures/external_components/lib/external_components.rb
@@ -1,0 +1,11 @@
+require "dry/system"
+
+Dry::System.register_provider(
+  :external_components,
+  boot_path: Pathname(__dir__).join('../components').realpath
+)
+
+Dry::System.register_provider(
+  :alt,
+  boot_path: Pathname(__dir__).join('../alt-components').realpath
+)

--- a/spec/integration/external_components_spec.rb
+++ b/spec/integration/external_components_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe 'External Components' do
+  subject(:container) do
+    Class.new(Dry::System::Container) { register_external(:logger, provider: :external_components) }
+  end
+
+  before do
+    require SPEC_ROOT.join('fixtures/external_components/lib/external_components')
+  end
+
+  context 'with default behavior' do
+    it 'boots external logger component' do
+      container.finalize!
+
+      expect(container[:logger]).to be_instance_of(ExternalComponents::Logger)
+    end
+  end
+
+  context 'with customized booting' do
+    it 'exposes :init lifecycle step' do
+      container.on(logger: :init) do
+        ExternalComponents::Logger.default_level = :error
+      end
+
+      container.finalize!
+
+      expect(container[:logger]).to be_instance_of(ExternalComponents::Logger)
+      expect(container[:logger].class.default_level).to be(:error)
+    end
+  end
+
+  context 'customized registration from an alternative provider' do
+    subject(:container) do
+      Class.new(Dry::System::Container) do
+        register_external(:logger, provider: :external_components)
+        register_external('alt.logger', provider: :alt, key: :logger)
+      end
+    end
+
+    before do
+      require SPEC_ROOT.join('fixtures/external_components/lib/external_components')
+    end
+
+    context 'with default behavior' do
+      it 'boots external logger component from the specified provider' do
+        container.finalize!
+
+        expect(container[:logger]).to be_instance_of(ExternalComponents::Logger)
+        expect(container['alt.logger']).to be_instance_of(AltComponents::Logger)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,5 +44,7 @@ RSpec.configure do |config|
 
     Test.remove_constants
     Object.send(:remove_const, :Test)
+
+    Dry::System.instance_variable_set('@__providers__', Dry::System::ProviderRegistry.new)
   end
 end

--- a/spec/unit/container/finalize_spec.rb
+++ b/spec/unit/container/finalize_spec.rb
@@ -68,13 +68,13 @@ RSpec.describe Dry::System::Container, '.finalize' do
 
   specify 'start raises error on undefined method or variable' do
     expect {
-      system.finalize(:db) { oops('arg') }
-      system.booter.start(:db)
+      system.finalize(:broken) { oops('arg') }
+      system.booter.start(:broken)
     }.to raise_error(NoMethodError, /oops/)
 
     expect {
-      system.finalize(:db) { oops }
-      system.booter.start(:db)
+      system.finalize(:broken) { oops }
+      system.booter.start(:broken)
     }.to raise_error(NameError, /oops/)
   end
 

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -129,12 +129,6 @@ RSpec.describe Dry::System::Container do
         expect(container['test.bar']).to eql('I was finalized')
       end
 
-      it 'expects a symbol identifier matching file name' do
-        expect {
-          container.start('bar')
-        }.to raise_error(ArgumentError, 'component identifier "bar" must be a symbol')
-      end
-
       it 'expects identifier to point to an existing boot file' do
         expect {
           container.start(:foo)
@@ -144,11 +138,11 @@ RSpec.describe Dry::System::Container do
         )
       end
 
-      describe "missmatch betwenn finalize name and registered component" do
+      describe "mismatch betwenn finalize name and registered component" do
         it "raises a meaningful error" do
           expect{
             container.start(:hell)
-          }.to raise_error(Dry::System::ComponentFileMismatchError)
+          }.to raise_error(Dry::System::InvalidComponentIdentifierError)
         end
       end
     end
@@ -180,20 +174,6 @@ RSpec.describe Dry::System::Container do
           end
         end
       end
-    end
-
-    it 'passes container to the finalizer block' do
-      class Test::Container < Dry::System::Container
-        configure { |c| c.name = :awesome }
-
-        finalize(:foo) do |container|
-          register(:w00t, container.config.name)
-        end
-      end
-
-      Test::Container.booter.(:foo)
-
-      expect(Test::Container[:w00t]).to be(:awesome)
     end
   end
 


### PR DESCRIPTION
This adds support for external components. To enable this we need to add a couple of new concepts, like a component provider and external component. This is still a WIP, but I got things figured out, so I'll clean this up and should be ready to go.

### API

``` ruby
# ie in a gem you can do this to register your provider
require "dry/system"

Dry::System.register_provider(
  :external_components,
  boot_path: Pathname(__dir__).join('../components').realpath
)

# then each component file can register something
# ie `../components/logger.rb'
require "dry/system"

Dry::System.register_component(:logger, provider: :external_components) do
  init do
    module ExternalComponents
      class Logger
      end
    end
  end

  start do
    register(:logger, ExternalComponents::Logger.new)
  end
end

# then in your container you can ask for an external logger:

# let's assume there's a gem called like that
require "external_components"

class MyContainer < Dry::System::Container
  register_external(:logger, provider: :external_components)
end

# you can use a custom registration key
class MyContainer < Dry::System::Container
  register_external(:logger, provider: :external_components, as: "core.logger")
end

# you can hook into its lifecycle too:
MyContainer.on(logger: :init) do |step|
  # here it's guaranteed that component init is done
end
```

### TODO

- [x] Add ability to register an external component
- [x] Add ability to register a component provider
- [x] Add ability to register a component using external identifier
- [x] Add ability to register components with the same identifiers under custom keys in the container
- [x] Add ability to select which provider should be used when registering an external component
- [x] Clean things up by introducing explicit `Provider` and `ExternalComponent` concepts (they should encapsulate all the required information, so that we don't have to pass many things around)