### PR TITLE
Allow instantiate component without namespace in its identifier

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -67,8 +67,8 @@ module Dry
       # @api private
       def self.remove_namespace_from_path(name, ns)
         match_value = name.match(/^(?<remove_namespace>#{ns}).(?<identifier>.*)/)
-        raise InvalidComponentError.new(name, "namespace +#{ns}+ not found in path") unless match_value
-        match_value[:identifier]
+
+        match_value ? match_value[:identifier] : name
       end
 
       # @api private

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Dry::System::Component do
       expect(component.identifier).to eql('user.foo.bar')
     end
 
-    it 'raises when namepsace is not present  in path' do
-      expect { Dry::System::Component.new('foo.bar.foo', namespace: 'baz') }
-        .to raise_error(Dry::System::InvalidComponentError, /baz/)
+    it 'returns the identifier if namespace is not present' do
+      component = Dry::System::Component.new('foo', namespace: 'admin')
+      expect(component.identifier).to eql('foo')
     end
   end
 

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -69,6 +69,24 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
     specify { expect(Test::Container['foo']).to be_a(Namespaced::Foo) }
   end
 
+  context 'standard loader with default namespace but boot files without' do
+    before do
+      class Test::Container < Dry::System::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join('fixtures').realpath
+          config.default_namespace = 'namespace'
+        end
+
+        load_paths!('components')
+        auto_register!('components')
+      end
+    end
+
+    specify { expect(Test::Container['foo']).to be_an_instance_of(Foo) }
+    specify { expect(Test::Container['bar']).to be_an_instance_of(Bar) }
+    specify { expect(Test::Container['bar.baz']).to be_an_instance_of(Bar::Baz) }
+  end
+
   context 'standard loader with a default namespace with multiple level' do
     before do
       class Test::Container < Dry::System::Container


### PR DESCRIPTION
@solnic as we talk about. This allows booting the component without namespace in its identifier