### PR TITLE
Add built-in :system_components with :settings component

### DIFF
--- a/dry-system.gemspec
+++ b/dry-system.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-container', '~> 0.6'
   spec.add_runtime_dependency 'dry-auto_inject', '>= 0.4.0'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.7', '>= 0.7.0'
+  spec.add_runtime_dependency 'dry-struct', '~> 0.3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/system/components.rb
+++ b/lib/dry/system/components.rb
@@ -1,0 +1,6 @@
+require 'dry/system'
+
+Dry::System.register_provider(
+  :system_components,
+  boot_path: Pathname(__dir__).join('system_components').realpath
+)

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -1,4 +1,5 @@
 require 'dry/system/lifecycle'
+require 'dry/system/settings'
 require 'dry/system/components/config'
 
 module Dry
@@ -88,8 +89,23 @@ module Dry
         end
 
         def configure(&block)
-          @config = Config.new(&block)
-          self
+          @config = settings.new(Config.new(&block)) if settings
+        end
+
+        def settings(&block)
+          if block
+            @settings = Settings::DSL.new(identifier, &block).call
+          else
+            @settings
+          end
+        end
+
+        def config
+          if @config
+            @config
+          else
+            configure
+          end
         end
 
         def container

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -16,8 +16,6 @@ module Dry
 
         attr_reader :triggers
 
-        attr_reader :config
-
         attr_reader :namespace
 
         def initialize(identifier, options = {}, &block)
@@ -89,7 +87,7 @@ module Dry
         end
 
         def configure(&block)
-          @config = settings.new(Config.new(&block)) if settings
+          @config_block = block
         end
 
         def settings(&block)
@@ -104,8 +102,12 @@ module Dry
           if @config
             @config
           else
-            configure
+            configure!
           end
+        end
+
+        def configure!
+          @config = settings.new(Config.new(&@config_block)) if settings
         end
 
         def container

--- a/lib/dry/system/components/config.rb
+++ b/lib/dry/system/components/config.rb
@@ -4,7 +4,7 @@ module Dry
       class Config
         def self.new(&block)
           config = super
-          yield(config)
+          yield(config) if block_given?
           config
         end
 

--- a/lib/dry/system/lifecycle.rb
+++ b/lib/dry/system/lifecycle.rb
@@ -1,5 +1,7 @@
 require 'concurrent/map'
 
+require 'dry/system/settings'
+
 module Dry
   module System
     # Lifecycle booting DSL
@@ -40,6 +42,7 @@ module Dry
       # @api private
       def initialize(container, opts, &block)
         @container = container
+        @settings = nil
         @statuses = []
         @triggers = {}
         @opts = opts
@@ -54,6 +57,11 @@ module Dry
             statuses << trigger
           end
         end
+      end
+
+      # @api private
+      def settings(&block)
+        component.settings(&block)
       end
 
       # @api private

--- a/lib/dry/system/provider_registry.rb
+++ b/lib/dry/system/provider_registry.rb
@@ -3,18 +3,18 @@ module Dry
     class ProviderRegistry
       include Enumerable
 
-      attr_reader :providers
+      attr_reader :items
 
       def initialize
-        @providers = []
+        @items = []
       end
 
       def each(&block)
-        providers.each(&block)
+        items.each(&block)
       end
 
       def register(identifier, options)
-        providers << Provider.new(identifier, options)
+        items << Provider.new(identifier, options)
       end
 
       def [](identifier)

--- a/lib/dry/system/settings.rb
+++ b/lib/dry/system/settings.rb
@@ -1,0 +1,67 @@
+require "dry/core/class_builder"
+require "dry/types"
+require "dry/struct"
+
+require "dry/system/settings/file_loader"
+
+module Dry
+  module System
+    module Settings
+      module Types
+        include Dry::Types.module
+      end
+
+      class DSL < BasicObject
+        attr_reader :identifier
+
+        attr_reader :schema
+
+        def initialize(identifier, &block)
+          @identifier = identifier
+          @schema = {}
+          instance_eval(&block)
+        end
+
+        def call
+          Core::ClassBuilder.new(name: 'Configuration', parent: Settings::Configuration).call do |klass|
+            schema.each do |key, type|
+              klass.setting(key, type)
+            end
+          end
+        end
+
+        def key(name, type)
+          schema[name] = type
+        end
+
+        def type(id)
+          Types::Strict.const_get(id.to_s)
+        end
+      end
+
+      class Configuration < Dry::Struct
+        constructor_type :strict_with_defaults
+
+        def self.setting(*args)
+          attribute(*args)
+        end
+
+        def self.load(root, env)
+          env_data = load_files(root, env)
+
+          attributes = schema.each_with_object({}) do |(key, type), h|
+            value = ENV.fetch(key.to_s.upcase) { env_data[key.to_s.upcase] }
+            h[key] = value
+          end
+
+          new(attributes)
+        end
+
+        def self.load_files(root, env)
+          FileLoader.new.(root, env)
+        end
+        private_class_method :load_files
+      end
+    end
+  end
+end

--- a/lib/dry/system/settings/file_loader.rb
+++ b/lib/dry/system/settings/file_loader.rb
@@ -1,0 +1,28 @@
+require "dry/system/settings/file_parser"
+
+module Dry
+  module System
+    module Settings
+      class FileLoader
+        def call(root, env)
+          files(root, env).reduce({}) do |hash, file|
+            hash.merge(parser.(file))
+          end
+        end
+
+        private
+
+        def parser
+          @parser ||= FileParser.new
+        end
+
+        def files(root, env)
+          [
+            root.join(".env"),
+            root.join(".env.#{env}")
+          ].compact
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/settings/file_parser.rb
+++ b/lib/dry/system/settings/file_parser.rb
@@ -1,0 +1,49 @@
+module Dry
+  module System
+    module Settings
+      class FileParser
+        # Regex extracted from dotenv gem
+        # https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/parser.rb#L14
+        LINE = %r(
+          \A
+          \s*
+          (?:export\s+)?    # optional export
+          ([\w\.]+)         # key
+          (?:\s*=\s*|:\s+?) # separator
+          (                 # optional value begin
+            '(?:\'|[^'])*'  #   single quoted value
+            |               #   or
+            "(?:\"|[^"])*"  #   double quoted value
+            |               #   or
+            [^#\n]+         #   unquoted value
+          )?                # value end
+          \s*
+          (?:\#.*)?         # optional comment
+          \z
+        )x
+
+        def call(file)
+          File.readlines(file).each_with_object({}) do |line, hash|
+            parse_line(line, hash)
+          end
+        rescue Errno::ENOENT
+          {}
+        end
+
+        private
+
+        def parse_line(line, hash)
+          if (match = line.match(LINE))
+            key, value = match.captures
+            hash[key] = parse_value(value || "")
+          end
+          hash
+        end
+
+        def parse_value(value)
+          value.strip.sub(/\A(['"])(.*)\1\z/, '\2')
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/system_components/settings.rb
+++ b/lib/dry/system/system_components/settings.rb
@@ -1,0 +1,9 @@
+Dry::System.register_component(:settings, provider: :system_components) do
+  init do
+    require 'dry/system/settings'
+  end
+
+  start do
+    register(:settings, settings.load(target.root, target.env))
+  end
+end

--- a/lib/dry/system/system_components/settings.rb
+++ b/lib/dry/system/system_components/settings.rb
@@ -4,6 +4,6 @@ Dry::System.register_component(:settings, provider: :system_components) do
   end
 
   start do
-    register(:settings, settings.load(target.root, target.env))
+    register(:settings, settings.load(target.root, target.config.env))
   end
 end

--- a/spec/fixtures/external_components/components/logger.rb
+++ b/spec/fixtures/external_components/components/logger.rb
@@ -1,6 +1,10 @@
 require "dry/system"
 
 Dry::System.register_component(:logger, provider: :external_components) do
+  settings do
+    key :log_level, type(Symbol).default(:scream)
+  end
+
   init do
     module ExternalComponents
       class Logger

--- a/spec/fixtures/settings_test/.env
+++ b/spec/fixtures/settings_test/.env
@@ -1,0 +1,1 @@
+SESSION_SECRET="super-secret"

--- a/spec/integration/boot_spec.rb
+++ b/spec/integration/boot_spec.rb
@@ -20,45 +20,35 @@ RSpec.describe Dry::System::Container, '.boot' do
     end
   end
 
-  context 'inline booting' do
+  context 'using predefined settings for configuration' do
     before do
       class Test::Container < Dry::System::Container
       end
     end
 
-    it 'allows setting up configuration and lifycycle steps' do
-      system.boot(:db) do
-        configure do |config|
-          config.host = 'localhost'
-          config.user = 'root'
-          config.pass = 'secret'
-          config.database = 'test'
-          config.scheme = 'postgresql'
-        end
-
-        init do
-          module Test
-            class Db < OpenStruct
-            end
-          end
+    it 'uses defaults' do
+      system.boot(:api) do
+        settings do
+          key :token, type(String).default('xxx')
         end
 
         start do
-          register(:conn, Test::Db.new(config.to_hash))
+          register(:client, OpenStruct.new(config.to_hash))
         end
       end
 
-      system.start(:db)
+      system.start(:api)
 
-      conn = system[:conn]
+      client = system[:client]
 
-      expect(conn).to be_instance_of(Test::Db)
+      expect(client.token).to eql('xxx')
+    end
+  end
 
-      expect(conn.host).to eql('localhost')
-      expect(conn.user).to eql('root')
-      expect(conn.pass).to eql('secret')
-      expect(conn.database).to eql('test')
-      expect(conn.scheme).to eql('postgresql')
+  context 'inline booting' do
+    before do
+      class Test::Container < Dry::System::Container
+      end
     end
 
     it 'allows lazy-booting' do

--- a/spec/integration/external_components_spec.rb
+++ b/spec/integration/external_components_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'External Components' do
         boot(:logger, from: :external_components)
 
         boot(:my_logger, from: :external_components, key: :logger) do
-          settings do
-            key :log_level, type(Symbol).default(:debug)
+          configure do |config|
+            config.log_level = :debug
           end
 
           after(:start) do |external_container|

--- a/spec/integration/external_components_spec.rb
+++ b/spec/integration/external_components_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'External Components' do
         boot(:logger, from: :external_components)
 
         boot(:my_logger, from: :external_components, key: :logger) do
-          configure do |config|
-            config.log_level = :debug
+          settings do
+            key :log_level, type(Symbol).default(:debug)
           end
 
           after(:start) do |external_container|

--- a/spec/integration/settings_component_spec.rb
+++ b/spec/integration/settings_component_spec.rb
@@ -3,8 +3,11 @@ require 'dry/system/components'
 RSpec.describe 'Settings component' do
   subject(:system) do
     Class.new(Dry::System::Container) do
+      setting :env
+
       configure do |config|
         config.root = SPEC_ROOT.join('fixtures').join('settings_test')
+        config.env = :test
       end
 
       boot(:settings, from: :system_components) do
@@ -12,10 +15,6 @@ RSpec.describe 'Settings component' do
           key :database_url, type(String).constrained(filled: true)
           key :session_secret, type(String).constrained(filled: true)
         end
-      end
-
-      def self.env
-        :test
       end
     end
   end

--- a/spec/integration/settings_component_spec.rb
+++ b/spec/integration/settings_component_spec.rb
@@ -1,0 +1,39 @@
+require 'dry/system/components'
+
+RSpec.describe 'Settings component' do
+  subject(:system) do
+    Class.new(Dry::System::Container) do
+      configure do |config|
+        config.root = SPEC_ROOT.join('fixtures').join('settings_test')
+      end
+
+      boot(:settings, from: :system_components) do
+        settings do
+          key :database_url, type(String).constrained(filled: true)
+          key :session_secret, type(String).constrained(filled: true)
+        end
+      end
+
+      def self.env
+        :test
+      end
+    end
+  end
+
+  let(:settings) do
+    system[:settings]
+  end
+
+  before do
+    ENV['DATABASE_URL'] = 'sqlite::memory'
+  end
+
+  after do
+    ENV.delete('DATABASE_URL')
+  end
+
+  it 'sets up system settings component via ENV and .env' do
+    expect(settings.database_url).to eql('sqlite::memory')
+    expect(settings.session_secret).to eql('super-secret')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,6 @@ RSpec.configure do |config|
     Test.remove_constants
     Object.send(:remove_const, :Test)
 
-    Dry::System.instance_variable_set('@__providers__', Dry::System::ProviderRegistry.new)
+    Dry::System.providers.items.delete_if { |p| p.identifier != :system_components }
   end
 end


### PR DESCRIPTION
This introduces built-in `:system_components` with the very first one called `:settings`. It also adds `settings` DSL for bootable components where you can define structure of your settings with setting keys and their types (and it enforces strict types).

Example usage:

``` ruby
class MyApp < Dry::System::Container
  boot :settings, from: :system_components do
    settings do
      key :database_url, type(String).constrained(filled: true)
    end
  end
end

# this uses ENV and .env and .env.#{config.env} to pull in values
MyApp[:settings].database_url
```

Bootable components can ship with their settings predefined too:

``` ruby
Dry::System.register_component(:logger, provider: :some_provider) do
  setttings do
    key :output, type('Any').default($stdout)
    key :level, type(Symbol).default(:debug)
  end

  start do
    require 'some_provider/logger'

    register(:logger, Logger.new(config.output, level: config.level)
  end
end

# then you can boot it and customize:
boot(:logger, from: :some_provider) do
  configure do |c|
    c.level = :error
    c.output = container.root.join('log/app.log')
  end
end
```