### PR TITLE
Rename Container.require to Container.require_from_root

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -441,19 +441,19 @@ module Dry
         #
         # @example
         #   # sinle file
-        #   MyApp.require('lib/core')
+        #   MyApp.require_from_root('lib/core')
         #
         #   # glob
-        #   MyApp.require('lib/**/*')
+        #   MyApp.require_from_root('lib/**/*')
         #
         # @param *paths [Array<String>] one or more paths, supports globs too
         #
         # @api public
-        def require(*paths)
+        def require_from_root(*paths)
           paths.flat_map { |path|
             path.to_s.include?('*') ? Dir[root.join(path)] : root.join(path)
           }.each { |path|
-            Kernel.require path.to_s
+            require path.to_s
           }
         end
 
@@ -535,7 +535,7 @@ module Dry
             raise FileNotFoundError, component
           end
 
-          Kernel.require(component.path)
+          require component.path
 
           yield
         end

--- a/spec/integration/settings_component_spec.rb
+++ b/spec/integration/settings_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Settings component' do
 
       boot(:settings, from: :system) do
         before(:init) do
-          require "types"
+          require_from_root "types"
         end
 
         settings do

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -19,15 +19,15 @@ RSpec.describe Dry::System::Container do
       end
     end
 
-    describe '.require' do
+    describe '.require_from_root' do
       it 'requires a single file' do
-        container.require(Pathname('lib/test/models'))
+        container.require_from_root(Pathname('lib/test/models'))
 
         expect(Test.const_defined?(:Models)).to be(true)
       end
 
       it 'requires many files when glob pattern is passed' do
-        container.require(Pathname('lib/test/models/*.rb'))
+        container.require_from_root(Pathname('lib/test/models/*.rb'))
 
         expect(Test::Models.const_defined?(:User)).to be(true)
         expect(Test::Models.const_defined?(:Book)).to be(true)
@@ -35,7 +35,6 @@ RSpec.describe Dry::System::Container do
     end
 
     describe '.require_component' do
-
       shared_examples_for 'requireable' do
         it 'requires component file' do
           component = container.component('test/foo')
@@ -51,7 +50,7 @@ RSpec.describe Dry::System::Container do
 
       context 'when already required' do
         before do
-          Kernel.require('test/foo')
+          require 'test/foo'
         end
 
         it_behaves_like 'requireable'


### PR DESCRIPTION
Fixes #64 

@solnic @timriley I rename `Container.require` to `Container.require_from_root`. Along the way, I updated some documentation and replace some `Kernel.require` for plain `require`