### PR TITLE
Add notifications + monitoring plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'dry-events', git: 'https://github.com/dry-rb/dry-events.git', branch: 'master'
+gem 'dry-monitor', git: 'https://github.com/dry-rb/dry-monitor.git', branch: 'master'
+
 gem 'codeclimate-test-reporter', platforms: :mri
 
 group :tools do

--- a/lib/dry/system/plugins.rb
+++ b/lib/dry/system/plugins.rb
@@ -83,6 +83,9 @@ module Dry
 
       require 'dry/system/plugins/decorate'
       register(:decorate, Plugins::Decorate)
+
+      require 'dry/system/plugins/notifications'
+      register(:notifications, Plugins::Notifications)
     end
   end
 end

--- a/lib/dry/system/plugins.rb
+++ b/lib/dry/system/plugins.rb
@@ -86,6 +86,9 @@ module Dry
 
       require 'dry/system/plugins/notifications'
       register(:notifications, Plugins::Notifications)
+
+      require 'dry/system/plugins/monitoring'
+      register(:monitoring, Plugins::Monitoring)
     end
   end
 end

--- a/lib/dry/system/plugins.rb
+++ b/lib/dry/system/plugins.rb
@@ -80,6 +80,9 @@ module Dry
 
       require 'dry/system/plugins/env'
       register(:env, Plugins::Env)
+
+      require 'dry/system/plugins/decorate'
+      register(:decorate, Plugins::Decorate)
     end
   end
 end

--- a/lib/dry/system/plugins/decorate.rb
+++ b/lib/dry/system/plugins/decorate.rb
@@ -1,0 +1,22 @@
+module Dry
+  module System
+    module Plugins
+      # @api public
+      module Decorate
+        # @api public
+        def decorate(key, decorator:)
+          original = _container.delete(key.to_s)
+
+          if original.is_a?(Dry::Container::Item) && original.options[:call] && decorator.is_a?(Class)
+            register(key) do
+              decorator.new(original.call)
+            end
+          else
+            decorated = decorator.is_a?(Class) ? decorator.new(original) : decorator
+            register(key, decorated)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/plugins/monitoring.rb
+++ b/lib/dry/system/plugins/monitoring.rb
@@ -1,0 +1,80 @@
+require 'delegate'
+require 'dry/system/constants'
+require 'dry/events/publisher'
+
+module Dry
+  module System
+    module Plugins
+      # @api public
+      module Monitoring
+        class Proxy < SimpleDelegator
+          # @api private
+          def self.for(target, key:, methods: [], &block)
+            monitored_methods =
+              if methods.empty?
+                target.public_methods - Object.public_instance_methods
+              else
+                methods
+              end
+
+            Class.new(self) do
+              extend Dry::Core::ClassAttributes
+              include Dry::Events::Publisher[target.class.name]
+
+              defines :monitored_methods
+
+              attr_reader :__notifications__
+
+              monitored_methods(methods.empty? ? target.public_methods - Object.public_instance_methods : methods)
+
+              monitored_methods.each do |meth|
+                define_method(meth) do |*args, &block|
+                  object = __getobj__
+                  opts = { target: key, object: object, method: meth, args: args }
+
+                  __notifications__.instrument(:monitoring, opts) do
+                    object.public_send(meth, *args, &block)
+                  end
+                end
+              end
+            end
+          end
+
+          def initialize(target, notifications)
+            super(target)
+            @__notifications__ = notifications
+          end
+        end
+
+        # @api private
+        def self.extended(system)
+          super
+
+          system.use(:decorate)
+          system.use(:notifications)
+
+          system.after(:configure) do
+            self[:notifications].register_event(:monitoring)
+          end
+        end
+
+        # @api private
+        def monitor(key, options = EMPTY_HASH, &block)
+          notifications = self[:notifications]
+
+          resolve(key).tap do |target|
+            proxy = Proxy.for(target, options.merge(key: key))
+
+            if block
+              proxy.monitored_methods.each do |meth|
+                notifications.subscribe(:monitoring, target: key, method: meth, &block)
+              end
+            end
+
+            decorate(key, decorator: proxy.new(target, notifications))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/plugins/notifications.rb
+++ b/lib/dry/system/plugins/notifications.rb
@@ -1,0 +1,20 @@
+module Dry
+  module System
+    module Plugins
+      # @api public
+      module Notifications
+        # @api private
+        def self.extended(system)
+          system.after(:configure, &:register_notifications)
+        end
+
+        # @api private
+        def register_notifications
+          return self if key?(:notifications)
+          require 'dry/monitor/notifications'
+          register(:notifications, Monitor::Notifications.new(config.name))
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/plugins/notifications.rb
+++ b/lib/dry/system/plugins/notifications.rb
@@ -11,7 +11,7 @@ module Dry
         # @api private
         def register_notifications
           return self if key?(:notifications)
-          require 'dry/monitor/notifications'
+          require 'dry/monitor/notifications' unless Object.const_defined?('Dry::Monitor::Notifications')
           register(:notifications, Monitor::Notifications.new(config.name))
         end
       end

--- a/spec/unit/container/decorate_spec.rb
+++ b/spec/unit/container/decorate_spec.rb
@@ -1,0 +1,28 @@
+require 'delegate'
+
+RSpec.describe Dry::System::Container do
+  subject(:system) do
+    Class.new(Dry::System::Container) do
+      use :decorate
+    end
+  end
+
+  describe '.decorate' do
+    it 'decorates registered singleton object with provided decorator API' do
+      system.register(:foo, "foo")
+
+      system.decorate(:foo, decorator: SimpleDelegator)
+
+      expect(system[:foo]).to be_instance_of(SimpleDelegator)
+    end
+
+    it 'decorates registered object with provided decorator API' do
+      system.register(:foo) { "foo" }
+
+      system.decorate(:foo, decorator: SimpleDelegator)
+
+      expect(system[:foo]).to be_instance_of(SimpleDelegator)
+      expect(system[:foo].__getobj__).to eql("foo")
+    end
+  end
+end

--- a/spec/unit/container/monitor_spec.rb
+++ b/spec/unit/container/monitor_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe Dry::System::Container do
+  subject(:system) do
+    Class.new(Dry::System::Container) do
+      use :monitoring
+    end
+  end
+
+  describe '.monitor' do
+    let(:klass) do
+      Class.new do
+        def self.name
+          "Test::Class_#{__id__}"
+        end
+
+        def say(word, &block)
+          block.call if block
+          word
+        end
+
+        def other
+        end
+      end
+    end
+
+    let(:object) do
+      klass.new
+    end
+
+    before do
+      system.configure {}
+      system.register(:object, klass.new)
+    end
+
+    it 'monitors object public method calls' do
+      captured = []
+
+      system.monitor(:object) do |event|
+        captured << [event.id, event[:target], event[:method], event[:args]]
+      end
+
+      object = system[:object]
+      block_result = []
+      block = proc { block_result << true }
+
+      result = object.say("hi", &block)
+
+      expect(block_result).to eql([true])
+      expect(result).to eql("hi")
+
+      expect(captured).to eql([[:monitoring, :object, :say, ["hi"]]])
+    end
+
+    it 'monitors specified object method calls' do
+      captured = []
+
+      system.monitor(:object, methods: [:say]) do |event|
+        captured << [event.id, event[:target], event[:method], event[:args]]
+      end
+
+      object = system[:object]
+
+      object.say("hi")
+      object.other
+
+      expect(captured).to eql([[:monitoring, :object, :say, ["hi"]]])
+    end
+  end
+end

--- a/spec/unit/container/notifications_spec.rb
+++ b/spec/unit/container/notifications_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Dry::System::Container do
+  subject(:system) do
+    Class.new(Dry::System::Container) do
+      use :notifications
+    end
+  end
+
+  describe '.notifications' do
+    it 'returns configured notifications' do
+      system.configure {}
+
+      expect(system[:notifications]).to be_instance_of(Dry::Monitor::Notifications)
+    end
+  end
+end


### PR DESCRIPTION
This adds 3 plugins:

- `:decorate` a trivial plugin that allows re-registering an object by wrapping it with provided decorator
- `:notifications` copy/paste from dry-web
- `:monitoring` adds `monitor` method which enables object monitoring on top of notification system

## TODO

- [x] add `monitor` method
- [x] allow setting specific methods to be monitored
- [x] make `decorate` work with block-registration