### PR TITLE
Use variable already allocated for monitored_methods

### DIFF
--- a/lib/dry/system/plugins/monitoring/proxy.rb
+++ b/lib/dry/system/plugins/monitoring/proxy.rb
@@ -23,7 +23,7 @@ module Dry
 
               attr_reader :__notifications__
 
-              monitored_methods(methods.empty? ? target.public_methods - Object.public_instance_methods : methods)
+              monitored_methods(monitored_methods)
 
               monitored_methods.each do |meth|
                 define_method(meth) do |*args, &block|


### PR DESCRIPTION
@solnic I was reading the code and notice that we could use the already defined variable in `proxy.rb`
  
 If you prefer to use the inline style, let me know and I will remove the upper variable assigment