### PR TITLE
Fix namespace component identifier

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -66,7 +66,7 @@ module Dry
 
       # @api private
       def self.remove_namespace_from_path(name, ns)
-        match_value = name.match(/^(?<remove_namespace>#{ns}).(?<identifier>.*)/)
+        match_value = name.match(/^^(?<remove_namespace>#{ns})(?<separator>[\.\/])(?<identifier>.*)/)
 
         match_value ? match_value[:identifier] : name
       end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Dry::System::Component do
       component = Dry::System::Component.new('foo', namespace: 'admin')
       expect(component.identifier).to eql('foo')
     end
+
+    it 'allows namespace to collide with the identifier' do
+      component = Dry::System::Component.new(:mailer, namespace: "mail", separator: ".")
+      expect(component.identifier).to eql('mailer')
+    end
   end
 
   context 'when name is a symbol' do


### PR DESCRIPTION
Solves #75 

@solnic here is a fix for the wrong regex that was generating the incorrect identifier.

In your example:

```ruby
Dry::System::Component.new(:mailer, namespace: "mail", separator: ".")
=> #<Dry::System::Component identifier="r" path="mailer">
```

Tha path was incorrect because the separator was not included nor in the `identifier` or the `namespace` I think is a better to raise an error if a separator is specified and is not present in the `identifier` or in the `namespace`

WDYT? 