### PR TITLE
Fix Component . Extracting namespace from identifier 

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -59,14 +59,14 @@ module Dry
       # @api private
       def self.extract_identifier(name, ns, sep)
         name_s = name.to_s
-        identifier = ns ? remove_namespace_from_path(name_s, ns) : name_s
+        identifier = ns ? remove_namespace_from_name(name_s, ns) : name_s
 
         identifier.scan(WORD_REGEX).join(sep)
       end
 
       # @api private
-      def self.remove_namespace_from_path(name, ns)
-        match_value = name.match(/^(?<remove_namespace>#{ns}).(?<identifier>.*)/)
+      def self.remove_namespace_from_name(name, ns)
+        match_value = name.match(/^(?<remove_namespace>#{ns})(?<separator>\W)(?<identifier>.*)/)
 
         match_value ? match_value[:identifier] : name
       end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Dry::System::Component do
       component = Dry::System::Component.new('foo', namespace: 'admin')
       expect(component.identifier).to eql('foo')
     end
+
+    it 'allows namespace to collide with the identifier' do
+      component = Dry::System::Component.new(:mailer, namespace: "mail", separator: ".")
+      expect(component.identifier).to eql('mailer')
+    end
   end
 
   context 'when name is a symbol' do


### PR DESCRIPTION
Solves #75 

At component initialization, we extract the namespace option from the identifier, the regex we use need a little improvement.

```ruby
component = Dry::System::Component.new(:mailer, namespace: "mail", separator: ".")
componet.identifier # => mailer
```
