### PR TITLE
Use namespace for component path

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -49,11 +49,17 @@ module Dry
           ns, sep = options.values_at(:namespace, :separator)
           identifier = extract_identifier(name, ns, sep)
 
-          path = name.to_s.gsub(sep, PATH_SEPARATOR)
+          path = extract_path(identifier, ns, sep)
           loader = options.fetch(:loader, Loader).new(path)
 
           super(identifier, path, options.merge(loader: loader))
         end
+      end
+
+      def self.extract_path(identifier, ns, sep)
+        path = ns ? [ns, identifier].join(sep) : identifier
+
+        path.gsub(sep, PATH_SEPARATOR)
       end
 
       # @api private

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -12,24 +12,58 @@ RSpec.describe Dry::System::Component do
       expect(create.()).to be(create.())
     end
 
-    it 'allows to have the same key multiple times in the identifier/path' do
-      component = Dry::System::Component.new('foo.bar.foo', namespace: 'foo')
-      expect(component.identifier).to eql('bar.foo')
+    describe '.identifier' do
+      it 'allows to have the same key multiple times in the identifier/path' do
+        component = Dry::System::Component.new('foo.bar.foo', namespace: 'foo')
+        expect(component.identifier).to eql('bar.foo')
+      end
+
+      it 'removes only the initial part from the identifier/path' do
+        component = Dry::System::Component.new('foo.bar.foo.user.foo.bar', namespace: 'foo.bar.foo')
+        expect(component.identifier).to eql('user.foo.bar')
+      end
+
+      it 'returns the identifier if namespace is not present' do
+        component = Dry::System::Component.new('foo', namespace: 'admin')
+        expect(component.identifier).to eql('foo')
+      end
+
+      it 'allows namespace to collide with the identifier' do
+        component = Dry::System::Component.new(:mailer, namespace: "mail", separator: ".")
+        expect(component.identifier).to eql('mailer')
+      end
     end
 
-    it 'removes only the initial part from the identifier/path' do
-      component = Dry::System::Component.new('foo.bar.foo.user.foo.bar', namespace: 'foo.bar.foo')
-      expect(component.identifier).to eql('user.foo.bar')
-    end
+    describe '.path' do
+      it 'returns the correct path when no namespace is set' do
+        component = Dry::System::Component.new('foo.bar.foo')
+        expect(component.path).to eql('foo/bar/foo')
+      end
 
-    it 'returns the identifier if namespace is not present' do
-      component = Dry::System::Component.new('foo', namespace: 'admin')
-      expect(component.identifier).to eql('foo')
-    end
+      it 'returns the path correctly using custom separator' do
+        component = Dry::System::Component.new('foo-bar-foo', separator: '-')
+        expect(component.path).to eql('foo/bar/foo')
+      end
 
-    it 'allows namespace to collide with the identifier' do
-      component = Dry::System::Component.new(:mailer, namespace: "mail", separator: ".")
-      expect(component.identifier).to eql('mailer')
+      it 'returns the path correctly using custom separator and namespace' do
+        component = Dry::System::Component.new('foo-bar-foo', namespace: 'foo', separator: '-')
+        expect(component.path).to eql('foo/bar/foo')
+      end
+
+      it 'returns the correct path' do
+        component = Dry::System::Component.new('foo.bar.foo', namespace: 'foo')
+        expect(component.path).to eql('foo/bar/foo')
+      end
+
+      it 'returns the correct path for complex identifier and namespace' do
+        component = Dry::System::Component.new('foo.bar.foo.user.foo.bar', namespace: 'foo.bar.foo')
+        expect(component.path).to eql('foo/bar/foo/user/foo/bar')
+      end
+
+      it 'returns the correct path when the namespace is not present in the identifier' do
+        component = Dry::System::Component.new(:mailer, namespace: "mail")
+        expect(component.path).to eql('mail/mailer')
+      end
     end
   end
 

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -69,24 +69,6 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
     specify { expect(Test::Container['foo']).to be_a(Namespaced::Foo) }
   end
 
-  context 'standard loader with default namespace but boot files without' do
-    before do
-      class Test::Container < Dry::System::Container
-        configure do |config|
-          config.root = SPEC_ROOT.join('fixtures').realpath
-          config.default_namespace = 'namespace'
-        end
-
-        load_paths!('components')
-        auto_register!('components')
-      end
-    end
-
-    specify { expect(Test::Container['foo']).to be_an_instance_of(Foo) }
-    specify { expect(Test::Container['bar']).to be_an_instance_of(Bar) }
-    specify { expect(Test::Container['bar.baz']).to be_an_instance_of(Bar::Baz) }
-  end
-
   context 'standard loader with a default namespace with multiple level' do
     before do
       class Test::Container < Dry::System::Container


### PR DESCRIPTION
Fix #78 

@solnic I start using the `namespace` in the `path` that way component that specifies a namespace but is not present in the identifier will generate the correct path.

```ruby
Dry::System::Component.new(:mailer, namespace: "mail")
#<Dry::System::Component identifier="mailer" path="mail/mailer"> 
```

I removed the failing test because doesn't make much sense to specify a namespace and not have in the system. Maybe I'm missing something WDYT?