### PR TITLE
yard proper parameter names

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -350,7 +350,7 @@ module Dry
         #     load_paths!('lib')
         #   end
         #
-        # @param [Array<String>] *dirs
+        # @param [Array<String>] dirs
         #
         # @return [self]
         #
@@ -449,7 +449,7 @@ module Dry
         #   # glob
         #   MyApp.require_from_root('lib/**/*')
         #
-        # @param *paths [Array<String>] one or more paths, supports globs too
+        # @param paths [Array<String>] one or more paths, supports globs too
         #
         # @api public
         def require_from_root(*paths)

--- a/lib/dry/system/loader.rb
+++ b/lib/dry/system/loader.rb
@@ -41,7 +41,7 @@ module Dry
       #
       # Provided optional args are passed to object's constructor
       #
-      # @param [Array] *args Optional constructor args
+      # @param [Array] args Optional constructor args
       #
       # @return [Object]
       #


### PR DESCRIPTION
Yard does not require (and reports as invalid) ```*``` in arguments. This PR fixes that.
https://app.coditsu.io/dry-rb/builds/validations/056fe6ff-7d94-4634-ad73-805e42be0c1e/offenses?q[offense_name_cont]=UnknownParameterName