### PR TITLE
Fix manual component registration with Ruby 2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Gemfile.lock
 
 ## Specific to RubyMine
 .idea
+
+spec/fixtures/test/log/*.log

--- a/lib/dry/system/manual_registrar.rb
+++ b/lib/dry/system/manual_registrar.rb
@@ -31,7 +31,7 @@ module Dry
       def call(name)
         name = name.respond_to?(:root_key) ? name.root_key.to_s : name
 
-        require(root.join(config.registrations_dir, name))
+        require(root.join(config.registrations_dir, name).to_s)
       end
 
       def file_exists?(name)


### PR DESCRIPTION
`require` needs a `String` and doesn’t work with `Pathname` raising an exception.