### PR TITLE
use default value from settings Type 

### DIFF
--- a/lib/dry/system/settings.rb
+++ b/lib/dry/system/settings.rb
@@ -41,7 +41,7 @@ module Dry
 
           attributes = schema.each_with_object({}) do |(key, type), h|
             value = ENV.fetch(key.to_s.upcase) { env_data[key.to_s.upcase] }
-            h[key] = value
+            h[key] = value if value
           end
 
           new(attributes)


### PR DESCRIPTION
Fixes #84 

@solnic @andrewcroome I was able to track the issue down. Basically, we where explicitly passing the value as `nil` if the value wasn't found in `ENV` or in any of the `.env` files. To solve we just need not pass the key to the `Dry::Struct` `new` method.

So with this change instead of passing `{an_int: nil}` we pass `{}` and it will use the default value. Also this change in `Dry::Struct` helped https://github.com/dry-rb/dry-struct/pull/75