### PR TITLE
Add inflector to container settings

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -3,6 +3,7 @@ require 'pathname'
 require 'dry-auto_inject'
 require 'dry-configurable'
 require 'dry-container'
+require 'dry/inflector'
 
 require 'dry/core/deprecations'
 
@@ -75,6 +76,7 @@ module Dry
       setting :system_dir, 'system'.freeze
       setting :registrations_dir, 'container'.freeze
       setting :auto_register, []
+      setting :inflector, Dry::Inflector.new
       setting :loader, Dry::System::Loader
       setting :booter, Dry::System::Booter
       setting :auto_registrar, Dry::System::AutoRegistrar
@@ -525,6 +527,7 @@ module Dry
               loader: config.loader,
               namespace: config.default_namespace,
               separator: config.namespace_separator,
+              inflector: config.inflector,
               **options,
             )
           end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -1,3 +1,4 @@
+require 'dry/inflector'
 require 'dry/system/loader'
 require 'singleton'
 
@@ -60,5 +61,19 @@ RSpec.describe Dry::System::Loader, '#call' do
       expect(instance.one).to be(1)
       expect(instance.two).to be(2)
     end
+  end
+
+  context 'with a custom inflector' do
+    let(:inflector) { Dry::Inflector.new { |i| i.acronym('API') } }
+
+    subject(:loader) { Dry::System::Loader.new('test/api_bar', inflector) }
+
+    let(:constant) { Test::APIBar }
+
+    before do
+      Test::APIBar = Class.new
+    end
+
+    it_behaves_like 'object loader'
   end
 end


### PR DESCRIPTION
This makes it easier to provide a custom inflector. At the same time, this
change is not backward compatible with existing custom loaders since now their
constructors have to accept 2 arguments.

<img width="283" alt="image" src="https://user-images.githubusercontent.com/802486/40810696-502b0742-6537-11e8-8632-d0e77c23e7a5.png">

It's my first PR here, please be gentle!