### PR TITLE
add Container#stop

### DIFF
--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -99,7 +99,7 @@ module Dry
       # @api private
       def stop(name_or_component)
         call(name_or_component) do |component|
-          raise ComponentNotStaredError.new(name_or_component) unless booted.include?(component)
+          raise ComponentNotStartedError.new(name_or_component) unless booted.include?(component)
           component.stop
           yield if block_given?
         end

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -97,6 +97,15 @@ module Dry
       end
 
       # @api private
+      def stop(name_or_component)
+        call(name_or_component) do |component|
+          raise ComponentNotStaredError.new(name_or_component) unless booted.include?(component)
+          component.stop
+          yield if block_given?
+        end
+      end
+
+      # @api private
       def call(name_or_component)
         with_component(name_or_component) do |component|
           unless component

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -339,6 +339,21 @@ module Dry
           self
         end
 
+        # Stop a specific component but calls only `stop` lifecycle trigger
+        #
+        # @example
+        #   MyApp.stop(:persistence)
+        #
+        # @param [Symbol] name The name of a registered bootable component
+        #
+        # @return [self]
+        #
+        # @api public
+        def stop(name)
+          booter.stop(name)
+          self
+        end
+
         # Sets load paths relative to the container's root dir
         #
         # @example

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -62,9 +62,9 @@ module Dry
     # Error raised when trying to stop a component that hasn't started yet
     #
     # @api public
-    ComponentNotStaredError = Class.new(StandardError) do
-      def initialize(companent_name)
-        super("You can not stop a component that has not been started yet. Please use `start` method to start the component. system.start[:#{companent_name}]")
+    ComponentNotStartedError = Class.new(StandardError) do
+      def initialize(component_name)
+        super("You can not stop a component +#{component_name}+ has not been started.")
       end
     end
   end

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -64,7 +64,7 @@ module Dry
     # @api public
     ComponentNotStartedError = Class.new(StandardError) do
       def initialize(component_name)
-        super("You can not stop a component +#{component_name}+ has not been started.")
+        super("component +#{component_name}+ has not been started")
       end
     end
   end

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -58,5 +58,14 @@ module Dry
         super("component identifier #{name.inspect} must be a symbol")
       end
     end
+
+    # Error raised when trying to stop a component that hasn't started yet
+    #
+    # @api public
+    ComponentNotStaredError = Class.new(StandardError) do
+      def initialize(companent_name)
+        super("You can not stop a component that has not been started yet. Please use `start` method to start the component. system.start[:#{companent_name}]")
+      end
+    end
   end
 end

--- a/spec/integration/boot_spec.rb
+++ b/spec/integration/boot_spec.rb
@@ -63,11 +63,62 @@ RSpec.describe Dry::System::Container, '.boot' do
         start do
           register('db.conn', Test::Db.new(established?: true))
         end
-      end
 
+        stop do
+          db.conn.established = false
+        end
+      end
       conn = system['db.conn']
 
       expect(conn).to be_established
+    end
+
+    it 'allows stop component' do
+      system.boot(:db) do
+        init do
+          module Test
+            class Db < OpenStruct
+            end
+          end
+        end
+
+        start do
+          register('db.conn', Test::Db.new(established: true))
+        end
+
+        stop do |container|
+          container['db.conn'].established = false
+        end
+      end
+      system.start(:db)
+
+      conn = system['db.conn']
+      system.stop(:db)
+
+      expect(conn.established).to eq false
+    end
+
+    it 'raises an error when trying to stop a component that has not bee started' do
+      system.boot(:db) do
+        init do
+          module Test
+            class Db < OpenStruct
+            end
+          end
+        end
+
+        start do
+          register('db.conn', Test::Db.new(established: true))
+        end
+
+        stop do |container|
+          container['db.conn'].established = false
+        end
+      end
+
+      expect {
+        system.stop(:db)
+      }.to raise_error(Dry::System::ComponentNotStaredError)
     end
   end
 end

--- a/spec/integration/boot_spec.rb
+++ b/spec/integration/boot_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Dry::System::Container, '.boot' do
       expect(conn).to be_established
     end
 
-    it 'allows stop component' do
+    it 'allows component to be stopped' do
       system.boot(:db) do
         init do
           module Test
@@ -98,7 +98,7 @@ RSpec.describe Dry::System::Container, '.boot' do
       expect(conn.established).to eq false
     end
 
-    it 'raises an error when trying to stop a component that has not bee started' do
+    it 'raises an error when trying to stop a component that has not been started' do
       system.boot(:db) do
         init do
           module Test

--- a/spec/integration/boot_spec.rb
+++ b/spec/integration/boot_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Dry::System::Container, '.boot' do
 
       expect {
         system.stop(:db)
-      }.to raise_error(Dry::System::ComponentNotStaredError)
+      }.to raise_error(Dry::System::ComponentNotStartedError)
     end
   end
 end


### PR DESCRIPTION
Fixes #90 

@solnic @mainameiz I have added the `stop` method in `Container`.

It also raises an error when trying to stop a component that has not started yet.