### PR TITLE
Bug fix: Allow multiple lazy resolutions using same root as bootable component

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -575,7 +575,9 @@ module Dry
                 booter.start(bootable_dep)
               elsif importer.key?(root_key)
                 load_imported_component(component.namespaced(root_key))
-              else
+              end
+
+              if !key?(key)
                 load_local_component(component)
               end
             end

--- a/spec/fixtures/lazy_loading/shared_root_keys/lib/kitten_service/fetch_kitten.rb
+++ b/spec/fixtures/lazy_loading/shared_root_keys/lib/kitten_service/fetch_kitten.rb
@@ -1,0 +1,4 @@
+module KittenService
+  class FetchKitten
+  end
+end

--- a/spec/fixtures/lazy_loading/shared_root_keys/lib/kitten_service/submit_kitten.rb
+++ b/spec/fixtures/lazy_loading/shared_root_keys/lib/kitten_service/submit_kitten.rb
@@ -1,0 +1,4 @@
+module KittenService
+  class SubmitKitten
+  end
+end

--- a/spec/fixtures/lazy_loading/shared_root_keys/system/boot/kitten_service.rb
+++ b/spec/fixtures/lazy_loading/shared_root_keys/system/boot/kitten_service.rb
@@ -1,0 +1,12 @@
+Test::Container.boot(:kitten_service, namespace: true) do |container|
+  init do
+    module KittenService
+      class Client
+      end
+    end
+  end
+
+  start do
+    register "client", KittenService::Client.new
+  end
+end

--- a/spec/integration/container/lazy_loading/bootable_components_spec.rb
+++ b/spec/integration/container/lazy_loading/bootable_components_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe 'Lazy loading bootable components' do
+  describe 'Booting component when resolving another components with bootable component as root key' do
+    before do
+      module Test
+        class Container < Dry::System::Container
+          configure do |config|
+            config.root = SPEC_ROOT.join('fixtures/lazy_loading/shared_root_keys').realpath
+          end
+
+          load_paths! 'lib'
+        end
+      end
+    end
+
+    context 'Single container' do
+      it 'boots the component and can resolve multiple other components registered using the same root key' do
+        expect(Test::Container["kitten_service.fetch_kitten"]).to be
+        expect(Test::Container.keys).to include("kitten_service.client", "kitten_service.fetch_kitten")
+        expect(Test::Container["kitten_service.submit_kitten"]).to be
+        expect(Test::Container.keys).to include("kitten_service.client", "kitten_service.fetch_kitten", "kitten_service.submit_kitten")
+      end
+    end
+
+    context 'Bootable component in imported container' do
+      before do
+        module Test
+          class AnotherContainer < Dry::System::Container
+            import core: Container
+          end
+        end
+      end
+
+      it 'boots the component and can resolve multiple other components registered using the same root key' do
+        expect(Test::AnotherContainer["core.kitten_service.fetch_kitten"]).to be
+        expect(Test::AnotherContainer.keys).to include("core.kitten_service.client", "core.kitten_service.fetch_kitten")
+        expect(Test::AnotherContainer["core.kitten_service.submit_kitten"]).to be
+        expect(Test::AnotherContainer.keys).to include("core.kitten_service.client", "core.kitten_service.fetch_kitten", "core.kitten_service.submit_kitten")
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was a bug where a resolution for an object using the same root key as a bootable component (e.g. resolving `"kitten_service.fetch_kitten"` where there is a bootable component named `:kitten_service`) would only allow the _first_ object resolution to work. Subsequent resolutions (e.g. for “kitten_service.submit_kitten”) would raise `Dry::Container::Error` with a message like `Nothing registered with the key "kitten_service.submit_kitten"` (even when this component did actually exist).

The problem exists only when using a non-finalized container (i.e. when the container is lazy loading components). On the first resolution, `Dry::System::Container.load_component` doesn’t detect that there is a bootable component on the root_key, and calls `.load_local_component`, which resolves the named component _and_ also properly detects and boots the bootable component named by the root key. On the subsequent resolution, `.load_component` _does_ detect that the bootable component exists, and just tries to boot it again, totally skipping the call to `.load_local_component`, which means the named component never gets required/loaded, and we get the error.

At the root (heh) of this, this really seems to be a problem of muddled responsibilities between `.load_component` and `.load_local_component` when it comes to booting bootable components, as well as two different ways to detect bootable components, only one of which works when the container is non-finalized and has not previously loaded or booted that component.

Fixing the root cause will take a little more time and thinking, and bigger adjustments.

In the meantime, this bug is effectively resolved by changing `.load_component` to always check to see if the named component key exists after booting and components or importing other containers. If the key doesn’t exist at that point, _always_ run `.load_local_component` to find the matching file, require it, and register the component. If that fails, then it can raise a (legitimate) “Nothing registered with the key” error.

@solnic I'll merge this in a few days since I think it's a pretty small change to fix this particular case, and the rest of the gem continues to work as before (at least that's what the specs tell me). Hopefully that gives you a chance to look things over if you'd like to.

I might also flag 2 follow-up issues, for:

- Improving detection of bootable components for a lazy-loading (non-finalized) container when nothing has been booted previously
- Clearing up `.load_component` and `.load_local_component` so that they both handle bootable components in the same way (or even better, if only one of them has to deal with them).