### PR TITLE
Require pathname in spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'pathname'
+
 if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.3'
   require 'simplecov'
   SimpleCov.start


### PR DESCRIPTION
This is due to an issue reported in Truffleruby issues https://github.com/oracle/truffleruby/issues/1463

The problem lies in a fact, `pathname` is required by `codeclimate-test-reporter` gem working only under MRI. More clarified in this comment https://github.com/oracle/truffleruby/issues/1463#issuecomment-438401626 made by @eregon

This allows to run `dry-system` specs under Truffleruby