### PR TITLE
Add Container#shutdown!

### DIFF
--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -70,6 +70,15 @@ module Dry
       end
 
       # @api private
+      def shutdown
+        components.each do |component|
+          next unless booted.include?(component)
+
+          stop(component)
+        end
+      end
+
+      # @api private
       def init(name_or_component)
         with_component(name_or_component) do |component|
           call(component) do
@@ -100,7 +109,10 @@ module Dry
       def stop(name_or_component)
         call(name_or_component) do |component|
           raise ComponentNotStartedError.new(name_or_component) unless booted.include?(component)
+
           component.stop
+          booted.delete(component)
+
           yield if block_given?
         end
       end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -358,6 +358,11 @@ module Dry
           self
         end
 
+        def shutdown!
+          booter.shutdown
+          self
+        end
+
         # Sets load paths relative to the container's root dir
         #
         # @example


### PR DESCRIPTION
Fix #92 

@davydovanton @solnic I added the `shutdown!` method to stop all components.

I thought that if a component is not started, we shouldn't raise `ComponentNotStartedError` we simply skip it. My reason behind it is whatever the reason the user of `dry-system` for calling `shutdown!` is to stop everything, so if one component has not been stated it shouldn't affect, actually less work for us :)