### PR TITLE
Wrap `require` statement in an extension method

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -558,9 +558,20 @@ module Dry
             raise FileNotFoundError, component
           end
 
-          require component.path
+          require_path(component.path)
 
           yield
+        end
+
+        # Allows subclasses to use a different strategy for required files.
+        #
+        # E.g. apps that use `ActiveSupport::Dependencies::Loadable#require_dependency`
+        # will override this method to allow container managed dependencies to be reloaded
+        # for non-finalized containers.
+        #
+        # @api private
+        def require_path(path)
+          require path
         end
 
         # @api private

--- a/spec/fixtures/require_path/lib/test/foo.rb
+++ b/spec/fixtures/require_path/lib/test/foo.rb
@@ -1,0 +1,4 @@
+module Test
+  class Foo
+  end
+end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -98,6 +98,35 @@ RSpec.describe Dry::System::Container do
         expect { container.load_component("test.no_matching_file") }.not_to raise_error
       end
     end
+
+    describe '.require_path' do
+      before do
+        module Test
+          class FileLoader
+          end
+
+          class Container < Dry::System::Container
+            configure do |config|
+              config.root = SPEC_ROOT.join('fixtures/require_path').realpath
+            end
+
+            load_paths!('lib')
+
+            class << self
+              def require_path(path)
+                Test::FileLoader.(path)
+              end
+            end
+          end
+        end
+      end
+
+      it 'defines an extension point for subclasses to use alternatives to Kernel#require' do
+        expect(Test::FileLoader).to receive(:call).with('test/foo').and_return(true)
+
+        container.load_component('test.foo')
+      end
+    end
   end
 
   describe '.init' do


### PR DESCRIPTION
Per this [conversation](https://discourse.dry-rb.org/t/rails-development-and-dry-system/571/4), this change allows components like `dry-system-rails` to override the default strategy from using `Kernel#require` to `ActiveSupport::Dependencies::Loadable#require_dependency`.

E.g.
```ruby
class App < Dry::System::Container
  class << self
    def require_path(path)
      require_dependency(path)
    end
  end
end
```