### PR TITLE
Use class attribute for container namespace_separator setting

### DIFF
--- a/lib/dry/system/importer.rb
+++ b/lib/dry/system/importer.rb
@@ -18,7 +18,7 @@ module Dry
       # @api private
       def initialize(container)
         @container = container
-        @separator = container.config.namespace_separator
+        @separator = container.namespace_separator
         @registry = {}
       end
 


### PR DESCRIPTION
This is necessary to work with the latest dry-container, which (for dry-rb-wide dependency graph reasons) has switched from dry-configurable to simple dry-core class attributes for its config.