### PR TITLE
Travis: update CI matrix, include 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: ruby
-sudo: false
 cache: bundler
 bundler_args: --without tools
-script:
-  - bundle exec rake spec
 before_install: gem update --system
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.5.0
-  - 2.4.3
-  - 2.3.6
-  - jruby-9.1.9.0
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
+  - jruby-9.2.5.0
 notifications:
   email: false
   webhooks:


### PR DESCRIPTION
  - update MRI patch versions
  - include 2.6.1
  - update to latest release of JRuby
  - drop the unused `sudo: false` directive
  - drop the `script` directive which was the default Travis action already