### PR TITLE
Make dir listings order stable

### DIFF
--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -56,7 +56,7 @@ module Dry
 
       # @api private
       def files(dir)
-        Dir["#{root}/#{dir}/**/#{RB_GLOB}"]
+        ::Dir["#{root}/#{dir}/**/#{RB_GLOB}"].sort
       end
 
       # @api private

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -160,7 +160,7 @@ module Dry
 
       # @api private
       def boot_files
-        Dir["#{path}/**/#{RB_GLOB}"]
+        ::Dir["#{path}/**/#{RB_GLOB}"].sort
       end
 
       # @api private

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -260,7 +260,7 @@ module Dry
         #
         # @api private
         def container_boot_files
-          Dir[container.boot_path.join("**/#{RB_GLOB}")]
+          ::Dir[container.boot_path.join("**/#{RB_GLOB}")].sort
         end
 
         private

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -493,7 +493,7 @@ module Dry
         # @api public
         def require_from_root(*paths)
           paths.flat_map { |path|
-            path.to_s.include?('*') ? Dir[root.join(path)] : root.join(path)
+            path.to_s.include?('*') ? ::Dir[root.join(path)].sort : root.join(path)
           }.each { |path|
             require path.to_s
           }

--- a/lib/dry/system/manual_registrar.rb
+++ b/lib/dry/system/manual_registrar.rb
@@ -24,7 +24,7 @@ module Dry
 
       # @api private
       def finalize!
-        Dir[registrations_dir.join(RB_GLOB)].each do |file|
+        ::Dir[registrations_dir.join(RB_GLOB)].sort.each do |file|
           call(File.basename(file, RB_EXT))
         end
       end

--- a/lib/dry/system/provider.rb
+++ b/lib/dry/system/provider.rb
@@ -24,7 +24,7 @@ module Dry
       end
 
       def boot_files
-        Dir[boot_path.join("**/#{RB_GLOB}")]
+        ::Dir[boot_path.join("**/#{RB_GLOB}")].sort
       end
 
       def register_component(name, fn)


### PR DESCRIPTION
The order of result of `Dit.glob/Dir.[]` varies depending on the FS. In general, it shouldn't matter, however, in practice it may lead to random-looking crashes across different environments (like macos vs linux etc).