### PR TITLE
Attempt to lazy-load component when container is asked for `key?`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@
 
 source 'https://rubygems.org'
 
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/dry-rb/#{repo_name}" }
 
 gemspec
 
 gem 'bootsnap'
 gem 'dry-monitor'
+gem 'dry-container', github: 'dry-container'
 
 gem 'codeclimate-test-reporter', platforms: :mri
 

--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -51,7 +51,7 @@ module Dry
         files(dir)
           .map { |file_name| [file_name, file_options(file_name)] }
           .map { |(file_name, options)| component(relative_path(dir, file_name), **options) }
-          .reject { |component| key?(component.identifier) }
+          .reject { |component| registered?(component.identifier) }
       end
 
       # @api private
@@ -81,8 +81,8 @@ module Dry
       end
 
       # @api private
-      def key?(name)
-        container.key?(name)
+      def registered?(name)
+        container.registered?(name)
       end
 
       # @api private

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -191,7 +191,7 @@ module Dry
         # @api private
         def finalize
           lifecycle.container.each do |key, item|
-            container.register(key, item) unless container.key?(key)
+            container.register(key, item) unless container.registered?(key)
           end
           self
         end

--- a/lib/dry/system/lifecycle.rb
+++ b/lib/dry/system/lifecycle.rb
@@ -126,7 +126,7 @@ module Dry
 
       # @api private
       def method_missing(meth, *args, &block)
-        if target.key?(meth)
+        if target.registered?(meth)
           target[meth]
         elsif container.key?(meth)
           container[meth]

--- a/lib/dry/system/plugins/logging.rb
+++ b/lib/dry/system/plugins/logging.rb
@@ -32,7 +32,7 @@ module Dry
         #
         # @api private
         def register_logger
-          if key?(:logger)
+          if registered?(:logger)
             self
           elsif config.logger
             register(:logger, config.logger)

--- a/lib/dry/system/plugins/notifications.rb
+++ b/lib/dry/system/plugins/notifications.rb
@@ -17,7 +17,7 @@ module Dry
 
         # @api private
         def register_notifications
-          return self if key?(:notifications)
+          return self if registered?(:notifications)
 
           register(:notifications, Monitor::Notifications.new(config.name))
         end

--- a/spec/integration/container/plugins/logging_spec.rb
+++ b/spec/integration/container/plugins/logging_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Plugins / Logging' do
 
   context 'with default logger settings' do
     subject(:system) do
-      Class.new(Dry::System::Container) do
+      class Test::Container < Dry::System::Container
         use :env
         use :logging
       end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
     it { expect(Test::Container['bar.baz']).to be_an_instance_of(Bar::Baz) }
 
     it "doesn't register files with inline option 'auto_register: false'" do
-      expect(Test::Container.key?('no_register')).to eql false
+      expect(Test::Container.registered?('no_register')).to eql false
     end
   end
 
@@ -46,8 +46,8 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
 
       expect(Test::Container['foo']).to eql('foo')
 
-      expect(Test::Container.key?('bar')).to eql false
-      expect(Test::Container.key?('bar.baz')).to eql false
+      expect(Test::Container.registered?('bar')).to eql false
+      expect(Test::Container.registered?('bar.baz')).to eql false
     end
   end
 

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dry::System::Container, '.import' do
   it 'imports one container into another' do
     app.import(persistence: db)
 
-    expect(app.key?('persistence.users')).to be(false)
+    expect(app.registered?('persistence.users')).to be(false)
 
     app.finalize!
 


### PR DESCRIPTION
This also adds `Container.registered?` which acts as `key?` used to.
Besides it, `Container.resolve` not takes an optional block to make this interface consistent with dry-container.