### PR TITLE
Make dependency plugin immutable for different dry-system containers

### DIFF
--- a/lib/dry/system/plugins/dependency_graph.rb
+++ b/lib/dry/system/plugins/dependency_graph.rb
@@ -20,7 +20,7 @@ module Dry
             self[:notifications].register_event(:resolved_dependency)
             self[:notifications].register_event(:registered_dependency)
 
-            system.strategies(Stratagies.with_notifications(system[:notifications]))
+            strategies(Strategies)
           end
         end
 

--- a/lib/dry/system/plugins/dependency_graph/strategies.rb
+++ b/lib/dry/system/plugins/dependency_graph/strategies.rb
@@ -5,19 +5,8 @@ module Dry
     module Plugins
       module DependencyGraph
         # @api private
-        class Stratagies
+        class Strategies
           extend Dry::Container::Mixin
-
-          # @api private
-          def self.with_notifications(value)
-            @notifications = value
-            self
-          end
-
-          # @api private
-          def self.__notifications__
-            @notifications
-          end
 
           # @api private
           class Kwargs < Dry::AutoInject::Strategies::Kwargs
@@ -25,8 +14,7 @@ module Dry
 
             # @api private
             def define_initialize(klass)
-              notifications = ::Dry::System::Plugins::DependencyGraph::Stratagies.__notifications__
-              notifications.instrument(
+              @container['notifications'].instrument(
                 :resolved_dependency, dependency_map: dependency_map.to_h, target_class: klass
               )
               super(klass)


### PR DESCRIPTION
I still working on dry-system dependency graph plugin and found that current implementation use one notification. For example, we have 2 dry-system containers:

```ruby
class App < Dry::System::Container
  use :dependency_graph
  use :monitoring

  configure do |config|
    config.ignored_dependencies = %i[not_registered]
    config.auto_register = %w[lib]
    config.name = :main
  end

  load_paths!('lib')
end

class OtherApp < Dry::System::Container
  use :dependency_graph
  use :monitoring

  configure do |config|
    config.ignored_dependencies = %i[not_registered]
    config.name = :new_one
    config.auto_register = %w[]
  end
end
```

In this case, these two containers will use one `notifications` object (which was created in the last container). For prevent this behavior we need to make this plugin immutable for each container.

Also, I drop the unused code.