### PR TITLE
Accept proc for root setting

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -74,7 +74,10 @@ module Dry
 
       setting :name
       setting :default_namespace
-      setting(:root, Pathname.pwd.freeze) { |path| Pathname(path) }
+      setting(:root, Pathname.pwd.freeze) do |path|
+        path = path.is_a?(Proc) ? path.call : path
+        Pathname(path)
+      end
       setting :system_dir, 'system'
       setting :registrations_dir, 'container'
       setting :auto_register, []

--- a/spec/unit/container/config_spec.rb
+++ b/spec/unit/container/config_spec.rb
@@ -36,5 +36,13 @@ RSpec.describe Dry::System::Container, '.config' do
         expect(root).to eq Pathname('/tmp')
       end
     end
+
+    context 'proc provided' do
+      let(:configuration) { proc { |config| config.root = -> { '/tmp' } } }
+
+      it 'calls the proc and coerces the result to pathname' do
+        expect(Test::Container.root).to eq Pathname('/tmp')
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows a gem to use dry-system and set the root relative to the gem and not the software using the gem.

Per [previous discussion](https://discourse.dry-rb.org/t/3rd-party-bootable-component/505), I have the same requirement. I would also like to use `dry-system` to boot my gem. This PR allows me to set the proper root for a gem. Otherwise, the root can only be set relative to the software using the gem. For example:

```ruby
# /my/gem
module MyGem
  class MyContainer < Dry::System::Container
    configure do |config|
    config.root = -> { 'root' }
  end
end

# /somewhere/else
require 'my_gem'

MyContainer.root
# Before
#=> /somewhere/else/root
# After
#=> /my/gem/root
```