### PR TITLE
Ensure shared plugin dependencies are loaded once

### DIFF
--- a/lib/dry/system/plugins.rb
+++ b/lib/dry/system/plugins.rb
@@ -31,8 +31,10 @@ module Dry
         def load_dependencies
           Array(dependencies).each do |f|
             begin
-              require f unless Plugins.loaded_dependencies.include?(f)
-              Plugins.loaded_dependencies << f
+              next if Plugins.loaded_dependencies.include?(f.to_s)
+
+              require f
+              Plugins.loaded_dependencies << f.to_s
             rescue LoadError => e
               raise PluginDependencyMissing.new(name, e.message)
             end


### PR DESCRIPTION
And ensure that the Dry::System::Plugins.loaded_dependencies array doesn't contain duplicates

Previous to this, multiple plugins could load the same dependency by one including the dependency as a Pathname instance, and the other as a string. Dependencies would also be duplicated in the loaded_dependencies array even if they were already required