### PR TITLE
Set initial value for ivar

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -660,6 +660,7 @@ module Dry
           end
 
           klass.instance_variable_set(:@hooks, new_hooks)
+          klass.instance_variable_set(:@__finalized__, false)
           super
         end
 


### PR DESCRIPTION
Today I realized I've been having `@__finalized__ = false` in my projects for ages 🤦‍♂
This is a reminder it's a good thing to have `config.warnings = true` in `spec_helper`