### PR TITLE
Fail fast if auto_registrar config contains incorrect path

### DIFF
--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -56,7 +56,13 @@ module Dry
 
       # @api private
       def files(dir)
-        ::Dir["#{root}/#{dir}/**/#{RB_GLOB}"].sort
+        components_dir = File.join(root, dir)
+
+        unless ::Dir.exist?(components_dir)
+          raise ComponentsDirMissing, "Components dir '#{components_dir}' not found"
+        end
+
+        ::Dir["#{components_dir}/**/#{RB_GLOB}"].sort
       end
 
       # @api private

--- a/lib/dry/system/constants.rb
+++ b/lib/dry/system/constants.rb
@@ -12,6 +12,7 @@ module Dry
     DEFAULT_SEPARATOR = '.'
     WORD_REGEX = /\w+/.freeze
 
+    ComponentsDirMissing = Class.new(StandardError)
     DuplicatedComponentKeyError = Class.new(ArgumentError)
     InvalidSettingsError = Class.new(ArgumentError) do
       # @api private

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -177,4 +177,39 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
     it { expect(Test::Container['bar'].call).to eq("Welcome to my Moe's Tavern!") }
     it { expect(Test::Container['bar.baz']).to be_an_instance_of(Bar::Baz) }
   end
+
+  context 'when component directory is missing' do
+    context 'in config' do
+      before do
+        class Test::Container < Dry::System::Container
+          configure do |config|
+            config.root = SPEC_ROOT.join('fixtures').realpath
+            config.auto_register = %w[unknown_dir]
+          end
+        end
+      end
+
+      it 'warns about it' do
+        expect {
+          Test::Container.finalize!
+        }.to raise_error Dry::System::ComponentsDirMissing, %r{fixtures/unknown_dir}
+      end
+    end
+
+    context 'in auto_register! call' do
+      before do
+        class Test::Container < Dry::System::Container
+          configure do |config|
+            config.root = SPEC_ROOT.join('fixtures').realpath
+          end
+        end
+      end
+
+      it 'warns about it' do
+        expect {
+          Test::Container.auto_register!('unknown_dir')
+        }.to raise_error Dry::System::ComponentsDirMissing, %r{fixtures/unknown_dir}
+      end
+    end
+  end
 end


### PR DESCRIPTION
Check that the directory in the `config.auto_register = %w[dir]` or `container.auto_register!('dir')` exists and fail if it's not.

I found it a bit confusing that `auto_register!('persistence')` didn't warn me that it should be `lib/persistence`.