### PR TITLE
Misspelled plugin name raises meaningful error

### DIFF
--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -75,5 +75,14 @@ module Dry
         super("component +#{component_name}+ has not been started")
       end
     end
+
+    # Error raised when trying to use a plugin that does not exist.
+    #
+    # @api public
+    PluginNotFoundError = Class.new(StandardError) do
+      def initialize(plugin_name)
+        super("Plugin #{plugin_name.inspect} does not exist")
+      end
+    end
   end
 end

--- a/lib/dry/system/plugins.rb
+++ b/lib/dry/system/plugins.rb
@@ -81,7 +81,8 @@ module Dry
         @loaded_dependencies ||= []
       end
 
-      # Enable a plugin
+      # Enables a plugin if not already enabled.
+      # Raises error if plugin cannot be found in the plugin registry.
       #
       # Plugin identifier
       #
@@ -92,13 +93,14 @@ module Dry
       #
       # @api public
       def use(name, options = {})
-        unless enabled_plugins.include?(name)
-          plugin = Plugins.registry[name]
-          plugin.load_dependencies
-          plugin.apply_to(self, options)
+        return self if enabled_plugins.include?(name)
+        raise PluginNotFoundError, name unless (plugin = Plugins.registry[name])
 
-          enabled_plugins << name
-        end
+        plugin.load_dependencies
+        plugin.apply_to(self, options)
+
+        enabled_plugins << name
+
         self
       end
 

--- a/spec/integration/container/plugins_spec.rb
+++ b/spec/integration/container/plugins_spec.rb
@@ -236,4 +236,11 @@ RSpec.describe Dry::System::Container, '.use' do
       expect(system.plugin_test).to eql('bar')
     end
   end
+
+  context 'misspeled plugin name' do
+    it 'raises meaningful error' do
+      expect { system.use :wrong_name }
+        .to raise_error(Dry::System::PluginNotFoundError, 'Plugin :wrong_name does not exist')
+    end
+  end
 end


### PR DESCRIPTION
This pull request fixes #132.

**Note:** I wasn't sure where to put the new `Dry::System::PluginNotFoundError` definition. There are two files that contain error definitions, `lib/dry/system/constants.rb` and `lib/dry/system/errors.rb` and the latter seemed like the correct place. In fact, I'm not really sure whether it makes sense to have error definitions in the constants file, so let me know if I can move them.