### PR TITLE
Centralize error definitions in `lib/dry/system/errors.rb`

### DIFF
--- a/lib/dry/system/constants.rb
+++ b/lib/dry/system/constants.rb
@@ -11,36 +11,5 @@ module Dry
     PATH_SEPARATOR = '/'
     DEFAULT_SEPARATOR = '.'
     WORD_REGEX = /\w+/.freeze
-
-    ComponentsDirMissing = Class.new(StandardError)
-    DuplicatedComponentKeyError = Class.new(ArgumentError)
-    InvalidSettingsError = Class.new(ArgumentError) do
-      # @api private
-      def initialize(attributes)
-        message = <<~STR
-          Could not initialize settings. The following settings were invalid:
-
-          #{attributes_errors(attributes).join("\n")}
-        STR
-        super(message)
-      end
-
-      private
-
-      def attributes_errors(attributes)
-        attributes.map { |key, error| "#{key.name}: #{error}" }
-      end
-    end
-
-    # Exception raise when a plugin dependency failed to load
-    #
-    # @api public
-    PluginDependencyMissing = Class.new(StandardError) do
-      # @api private
-      def initialize(plugin, message, gem = nil)
-        details = gem ? "#{message} - add #{gem} to your Gemfile" : message
-        super("dry-system plugin #{plugin.inspect} failed to load its dependencies: #{details}")
-      end
-    end
   end
 end

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -84,5 +84,36 @@ module Dry
         super("Plugin #{plugin_name.inspect} does not exist")
       end
     end
+
+    ComponentsDirMissing = Class.new(StandardError)
+    DuplicatedComponentKeyError = Class.new(ArgumentError)
+    InvalidSettingsError = Class.new(ArgumentError) do
+      # @api private
+      def initialize(attributes)
+        message = <<~STR
+          Could not initialize settings. The following settings were invalid:
+
+          #{attributes_errors(attributes).join("\n")}
+        STR
+        super(message)
+      end
+
+      private
+
+      def attributes_errors(attributes)
+        attributes.map { |key, error| "#{key.name}: #{error}" }
+      end
+    end
+
+    # Exception raise when a plugin dependency failed to load
+    #
+    # @api public
+    PluginDependencyMissing = Class.new(StandardError) do
+      # @api private
+      def initialize(plugin, message, gem = nil)
+        details = gem ? "#{message} - add #{gem} to your Gemfile" : message
+        super("dry-system plugin #{plugin.inspect} failed to load its dependencies: #{details}")
+      end
+    end
   end
 end


### PR DESCRIPTION
This follows from the discussion about misplaced error definitions [here](https://github.com/dry-rb/dry-system/pull/135#issuecomment-576048485).