### PR TITLE
Use before(:configure) in plugins

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -112,9 +112,10 @@ module Dry
         #
         # @api public
         def configure(&block)
+          hooks[:before_configure].each { |hook| instance_eval(&hook) }
           super(&block)
           load_paths!(config.system_dir)
-          hooks[:configure].each { |hook| instance_eval(&hook) }
+          hooks[:after_configure].each { |hook| instance_eval(&hook) }
           self
         end
 
@@ -642,7 +643,11 @@ module Dry
 
         # @api private
         def after(event, &block)
-          hooks[event] << block
+          hooks[:"after_#{event}"] << block
+        end
+
+        def before(event, &block)
+          hooks[:"before_#{event}"] << block
         end
 
         # @api private

--- a/lib/dry/system/plugins.rb
+++ b/lib/dry/system/plugins.rb
@@ -94,6 +94,7 @@ module Dry
       # @api public
       def use(name, options = {})
         return self if enabled_plugins.include?(name)
+
         raise PluginNotFoundError, name unless (plugin = Plugins.registry[name])
 
         plugin.load_dependencies

--- a/lib/dry/system/plugins/bootsnap.rb
+++ b/lib/dry/system/plugins/bootsnap.rb
@@ -16,7 +16,7 @@ module Dry
         def self.extended(system)
           super
           system.use(:env)
-          system.before(:configure){ setting :bootsnap, DEFAULT_OPTIONS }
+          system.before(:configure) { setting :bootsnap, DEFAULT_OPTIONS }
           system.after(:configure, &:setup_bootsnap)
         end
 

--- a/lib/dry/system/plugins/bootsnap.rb
+++ b/lib/dry/system/plugins/bootsnap.rb
@@ -16,7 +16,7 @@ module Dry
         def self.extended(system)
           super
           system.use(:env)
-          system.setting :bootsnap, DEFAULT_OPTIONS
+          system.before(:configure){ setting :bootsnap, DEFAULT_OPTIONS }
           system.after(:configure, &:setup_bootsnap)
         end
 

--- a/lib/dry/system/plugins/dependency_graph.rb
+++ b/lib/dry/system/plugins/dependency_graph.rb
@@ -14,7 +14,9 @@ module Dry
 
           system.use(:notifications)
 
-          system.setting :ignored_dependencies, []
+          system.before(:configure) do
+            setting :ignored_dependencies, []
+          end
 
           system.after(:configure) do
             self[:notifications].register_event(:resolved_dependency)

--- a/lib/dry/system/plugins/logging.rb
+++ b/lib/dry/system/plugins/logging.rb
@@ -8,16 +8,18 @@ module Dry
       module Logging
         # @api private
         def self.extended(system)
-          system.setting :logger, reader: true
+          system.before(:configure) do
+            setting :logger, reader: true
 
-          system.setting :log_dir, 'log'
+            setting :log_dir, 'log'
 
-          system.setting :log_levels,
-            development: Logger::DEBUG,
-            test: Logger::DEBUG,
-            production: Logger::ERROR
+            setting :log_levels,
+              development: Logger::DEBUG,
+              test: Logger::DEBUG,
+              production: Logger::ERROR
 
-          system.setting :logger_class, ::Logger, reader: true
+            setting :logger_class, ::Logger, reader: true
+          end
 
           system.after(:configure, &:register_logger)
 

--- a/spec/integration/container/plugins_spec.rb
+++ b/spec/integration/container/plugins_spec.rb
@@ -174,7 +174,9 @@ RSpec.describe Dry::System::Container, '.use' do
     context 'inheritance' do
       before do
         Dry::System::Plugins.register(:test_plugin, plugin) do
-          setting(:trace, [], &:dup)
+          before(:configure) do
+            setting(:trace, [], &:dup)
+          end
 
           after(:configure) do
             config.trace << :works


### PR DESCRIPTION
Previously a plugin would fail to initialize if during booting something already called `configure` with a block (which finalizes config and freezes it, so it's no longer possible to add new settings).