### PR TITLE
Add args and hash strategies from auto inject to dependency graph plugin

### DIFF
--- a/lib/dry/system/plugins/dependency_graph/strategies.rb
+++ b/lib/dry/system/plugins/dependency_graph/strategies.rb
@@ -21,7 +21,34 @@ module Dry
             end
           end
 
+          # @api private
+          class Args < Dry::AutoInject::Strategies::Args
+            private
+
+            # @api private
+            def define_initialize(klass)
+              @container['notifications'].instrument(
+                :resolved_dependency, dependency_map: dependency_map.to_h, target_class: klass
+              )
+              super(klass)
+            end
+          end
+
+          class Hash < Dry::AutoInject::Strategies::Args
+            private
+
+            # @api private
+            def define_initialize(klass)
+              @container['notifications'].instrument(
+                :resolved_dependency, dependency_map: dependency_map.to_h, target_class: klass
+              )
+              super(klass)
+            end
+          end
+
           register :kwargs, Kwargs
+          register :args, Args
+          register :hash, Hash
           register :default, Kwargs
         end
       end


### PR DESCRIPTION
Hey, I forgot to add other strategies to dry-system dependency graph. We need to do it if we want to detect injectors for graph