### PR TITLE
Fix error with mutation of frozen container

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -90,8 +90,10 @@ module Dry
         def strategies(value = nil)
           if value
             @strategies = value
+          elsif defined?(@strategies) && @strategies
+            @strategies
           else
-            @strategies ||= Dry::AutoInject::Strategies
+            Dry::AutoInject::Strategies
           end
         end
 

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -308,4 +308,18 @@ RSpec.describe Dry::System::Container do
       expect(container.registered?('test.dep')).to be(true)
     end
   end
+
+  describe '.injector' do
+    subject(:container) { Test::InjectorContainer }
+
+    before do
+      class Test::InjectorContainer < Dry::System::Container
+      end
+      Test::InjectorContainer.finalize!
+    end
+
+    it 'checks if a component is registered' do
+      expect { container.injector }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Hey,

@vessi found an interesting bug related to `strategies` logic. You can reproduce this bug with this script:

```ruby
require 'dry/system/container'

class Container < Dry::System::Container
end

class Container2 < Dry::System::Container
  strategies # if you call empty `strategies` everything will be okay because we will mutate state from a not frozen container
end

Container.finalize!
Container2.finalize!

# We already mutate state in class method `strategies``
Import2 = Container2.injector
# Will fail
Import = Container.injector
```

If you call `injector` before `finalize!` everything will be okay. But if not you get an error message:
```
Traceback (most recent call last):
        2: from test.rb:15:in `<main>'
        1: from /Users/anton/.rvm/gems/ruby-2.5.0/bundler/gems/dry-system-6ff22632ebc2/lib/dry/system/container.rb:491:in `injector'
/Users/anton/.rvm/gems/ruby-2.5.0/bundler/gems/dry-system-6ff22632ebc2/lib/dry/system/container.rb:94:in `strategies': can't modify frozen #<Class:Container> (FrozenError)
```

As you can see this bug related to frozen container and `@strategies` mutation from this line: https://github.com/dry-rb/dry-system/blob/master/lib/dry/system/container.rb#L94

I created a patch which works well:

**Before patch**

![Screenshot 2020-02-26 at 01 16 13](https://user-images.githubusercontent.com/1147484/75294064-891ccb80-5838-11ea-8d04-0f95a69db775.jpg)

**After patch**

![Screenshot 2020-02-26 at 01 33 19](https://user-images.githubusercontent.com/1147484/75294066-89b56200-5838-11ea-8f1f-fed99cd3dfdd.jpg)

------

I have only one problem with this code. Now dry-system spam with `warning: instance variable @strategies not initialized` warning and I have no idea how I can fix it in the current implementation. Also, I'll be happy if you help me with it