### PR TITLE
Document require before plugin use

### DIFF
--- a/docsite/source/plugins.html.md
+++ b/docsite/source/plugins.html.md
@@ -11,6 +11,8 @@ Dry-system has already built-in plugins that you can enable, and it’s very eas
 You can now enable a default system logger by simply enabling `:logging` plugin, you can also configure log dir, level and provide your own logger class.
 
 ```ruby
+require "dry/system/components"
+
 class App < Dry::System::Container
   use :logging
 end
@@ -27,6 +29,8 @@ App.logger
 Another plugin is called `:monitoring` which allows you to enable object monitoring, which is built on top of dry-monitor’s instrumentation API. Let’s say you have an object registered under `"users.operations.create",` and you’d like to add additional logging:
 
 ```ruby
+require "dry/system/components"
+
 class App < Dry::System::Container
   use :logging
   use :monitoring
@@ -50,6 +54,8 @@ end
 Environment can now be set in a non-web systems too. Previously this was only possible in dry-web, now any ruby app based on dry-system can use this configuration setting via `:env` plugin:
 
 ```ruby
+require "dry/system/components"
+
 class App < Dry::System::Container
   use :env
 
@@ -76,6 +82,8 @@ end
 dry-system is already pretty fast, but in a really big apps, it can take over 2 seconds to boot. You can now speed it up significantly by using `:bootsnap` plugin, which simply configures bootsnap for you:
 
 ```ruby
+require "dry/system/components"
+
 class App < Dry::System::Container
   use :bootsnap # that's it
 end


### PR DESCRIPTION
The `dry/system/components` file must be required for `dry-system` plugins to be usable.