### PR TITLE
Fix redefinition warnings happening on spec/integration

### DIFF
--- a/spec/fixtures/external_components/components/logger.rb
+++ b/spec/fixtures/external_components/components/logger.rb
@@ -22,7 +22,7 @@ Dry::System.register_component(:logger, provider: :external_components) do
           @log_level = log_level
         end
       end
-    end
+    end unless defined?(ExternalComponents)
   end
 
   start do

--- a/spec/integration/container/plugins/dependency_graph_spec.rb
+++ b/spec/integration/container/plugins/dependency_graph_spec.rb
@@ -2,6 +2,9 @@
 
 RSpec.describe "Plugins / Dependency Graph" do
   before do
+    Object.send(:remove_const, :ExternalComponents) if defined? ExternalComponents
+  end
+  before do
     require SPEC_ROOT.join("fixtures/external_components/lib/external_components")
 
     module Test


### PR DESCRIPTION
**spec/integration/external_components**

The ExternalComponent::Loger class is defined in the :init block of components/logger, and the system under test has two booters:

- :logger
-  :my_logger

These booters are using the same external component, executing the :init proc twice as expected on the lifecycle.

Since the definition is executed (twice) in a proc triggered inside the RSpec example it escapes the removal done on the RSpec.before hook.

Using a guard avoid the redefinition, fixing the warnings.

**spec/integration/../dependency_graph_spec**

The removal of ExternalComponent module was missing, this should be done as we do on external_components_spec.rb

If accepted, will change the spec report from this:

![image](https://user-images.githubusercontent.com/1037088/89761454-4166c500-daa3-11ea-9a47-0cc5d90b3417.png)

To this:

![image](https://user-images.githubusercontent.com/1037088/89761515-64917480-daa3-11ea-94c7-a4ca5de0c5a0.png)

