### PR TITLE
Support multiple boot file dirs

### DIFF
--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -129,11 +129,6 @@ module Dry
       end
 
       # @api private
-      def lifecycle_container(container)
-        LifecycleContainer.new(container)
-      end
-
-      # @api private
       def with_component(id_or_component)
         component =
           case id_or_component

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -120,7 +120,7 @@ module Dry
       # @api private
       def call(name_or_component)
         with_component(name_or_component) do |component|
-          raise ComponentFileMismatchError.new(name, registered_booted_keys) unless component
+          raise ComponentFileMismatchError.new(name) unless component
 
           yield(component) if block_given?
 

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -5,6 +5,7 @@ require "dry/system/errors"
 require "dry/system/constants"
 require "dry/system/lifecycle"
 require "dry/system/booter/component_registry"
+require "pathname"
 
 module Dry
   module System
@@ -16,43 +17,27 @@ module Dry
     #
     # @api private
     class Booter
-      attr_reader :path
+      attr_reader :paths
 
       attr_reader :booted
 
       attr_reader :components
 
       # @api private
-      def initialize(path)
-        @path = path
+      def initialize(paths)
+        @paths = paths
         @booted = []
         @components = ComponentRegistry.new
       end
 
       # @api private
       def bootable?(component)
-        boot_file(component).exist?
-      end
-
-      # @api private
-      def boot_file(name)
-        name = name.respond_to?(:root_key) ? name.root_key.to_s : name
-
-        path.join("#{name}#{RB_EXT}")
+        !boot_file(component).nil?
       end
 
       # @api private
       def register_component(component)
         components.register(component)
-        self
-      end
-
-      # @api private
-      def load_component(path)
-        identifier = Pathname(path).basename(RB_EXT).to_s.to_sym
-
-        Kernel.require path unless components.exists?(identifier)
-
         self
       end
 
@@ -120,7 +105,7 @@ module Dry
       # @api private
       def call(name_or_component)
         with_component(name_or_component) do |component|
-          raise ComponentFileMismatchError.new(name) unless component
+          raise ComponentFileMismatchError, name unless component
 
           yield(component) if block_given?
 
@@ -129,6 +114,14 @@ module Dry
       end
 
       # @api private
+      def boot_dependency(component)
+        boot_file = boot_file(component)
+
+        start(boot_file.basename(".*").to_s.to_sym) if boot_file
+      end
+
+      private
+
       def with_component(id_or_component)
         component =
           case id_or_component
@@ -144,24 +137,43 @@ module Dry
         yield(component)
       end
 
-      # @api private
+      def load_component(path)
+        identifier = Pathname(path).basename(RB_EXT).to_s.to_sym
+
+        Kernel.require path unless components.exists?(identifier)
+
+        self
+      end
+
+      def boot_file(name)
+        name = name.respond_to?(:root_key) ? name.root_key.to_s : name
+
+        find_boot_file(name)
+      end
+
       def require_boot_file(identifier)
-        boot_file = boot_files.detect { |path|
-          Pathname(path).basename(RB_EXT).to_s == identifier.to_s
-        }
+        boot_file = find_boot_file(identifier)
 
         Kernel.require boot_file if boot_file
       end
 
-      # @api private
-      def boot_files
-        ::Dir["#{path}/**/#{RB_GLOB}"].sort
+      def find_boot_file(name)
+        boot_files.detect { |file| File.basename(file, RB_EXT) == name.to_s }
       end
 
-      # @api private
-      def boot_dependency(component)
-        boot_file = boot_file(component)
-        start(boot_file.basename(".*").to_s.to_sym) if boot_file.exist?
+      def boot_files
+        @boot_files ||= paths.each_with_object([[], []]) { |path, (boot_files, loaded)|
+          files = Dir["#{path}/#{RB_GLOB}"].sort
+
+          files.each do |file|
+            basename = File.basename(file)
+
+            unless loaded.include?(basename)
+              boot_files << Pathname(file)
+              loaded << basename
+            end
+          end
+        }.first
       end
     end
   end

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -118,7 +118,7 @@ module Dry
       ruby2_keywords(:instance) if respond_to?(:ruby2_keywords, true)
 
       # @api private
-      def boot?
+      def bootable?
         false
       end
 

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -233,16 +233,6 @@ module Dry
           true
         end
 
-        # Return path to component's boot file
-        #
-        # @return [String]
-        #
-        # @api private
-        def boot_file
-          container_boot_files
-            .detect { |path| Pathname(path).basename(RB_EXT).to_s == identifier.to_s }
-        end
-
         # Return path to boot dir
         #
         # @return [String]

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -233,24 +233,6 @@ module Dry
           true
         end
 
-        # Return path to boot dir
-        #
-        # @return [String]
-        #
-        # @api private
-        def boot_path
-          container.boot_path
-        end
-
-        # Return all boot files defined under container's boot path
-        #
-        # @return [String]
-        #
-        # @api private
-        def container_boot_files
-          ::Dir[container.boot_path.join("**/#{RB_GLOB}")].sort
-        end
-
         private
 
         # Return lifecycle object used for this component

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -229,7 +229,7 @@ module Dry
         # @return [TrueClass]
         #
         # @api private
-        def boot?
+        def bootable?
           true
         end
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -48,8 +48,6 @@ module Dry
     #
     # * `:name` - a unique container identifier
     # * `:root` - a system root directory (defaults to `pwd`)
-    # * `:system_dir` - directory name relative to root, where bootable components
-    #                 can be defined in `boot` dir this defaults to `system`
     #
     # @example
     #   class MyApp < Dry::System::Container
@@ -76,6 +74,7 @@ module Dry
       setting :default_namespace
       setting(:root, Pathname.pwd.freeze) { |path| Pathname(path) }
       setting :system_dir, "system"
+      setting :bootable_dirs, ["system/boot"]
       setting :registrations_dir, "container"
       setting :auto_register, []
       setting :inflector, Dry::Inflector.new
@@ -170,9 +169,10 @@ module Dry
 
         # Registers finalization function for a bootable component
         #
-        # By convention, boot files for components should be placed in
-        # `%{system_dir}/boot` and they will be loaded on demand when components
-        # are loaded in isolation, or during finalization process.
+        # By convention, boot files for components should be placed in a
+        # `bootable_dirs` entry and they will be loaded on demand when
+        # components are loaded in isolation, or during the finalization
+        # process.
         #
         # @example
         #   # system/container.rb
@@ -563,12 +563,20 @@ module Dry
 
         # @api private
         def booter
-          @booter ||= config.booter.new(boot_path)
+          @booter ||= config.booter.new(boot_paths)
         end
 
         # @api private
-        def boot_path
-          root.join("#{config.system_dir}/boot")
+        def boot_paths
+          config.bootable_dirs.map { |dir|
+            dir = Pathname(dir)
+
+            if dir.relative?
+              root.join(dir)
+            else
+              dir
+            end
+          }
         end
 
         # @api private
@@ -629,13 +637,13 @@ module Dry
           return self if registered?(key)
 
           component(key).tap do |component|
-            if component.boot?
+            if component.bootable?
               booter.start(component)
             else
               root_key = component.root_key
 
-              if (bootable_dep = component(root_key)).boot?
-                booter.start(bootable_dep)
+              if (root_bootable = component(root_key)).bootable?
+                booter.start(root_bootable)
               elsif importer.key?(root_key)
                 load_imported_component(component.namespaced(root_key))
               end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -255,30 +255,24 @@ module Dry
               boot_local(name, **opts, &block)
             end
 
+          booter.register_component component
+
           components[name] = component
         end
         deprecate :finalize, :boot
 
         # @api private
         def boot_external(identifier, from:, key: nil, namespace: nil, &block)
-          component = System.providers[from].component(
+          System.providers[from].component(
             identifier, key: key, namespace: namespace, finalize: block, container: self
           )
-
-          booter.register_component(component)
-
-          component
         end
 
         # @api private
         def boot_local(identifier, namespace: nil, &block)
-          component = Components::Bootable.new(
+          Components::Bootable.new(
             identifier, container: self, namespace: namespace, &block
           )
-
-          booter.register_component(component)
-
-          component
         end
 
         # Return if a container was finalized

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -17,12 +17,8 @@ module Dry
     # @api public
     ComponentFileMismatchError = Class.new(StandardError) do
       def initialize(component)
-        path = component.boot_path
-        files = component.container_boot_files
-
         super(<<-STR)
-          Boot file for component #{component.identifier.inspect} not found.
-          Container boot files under #{path}: #{files.inspect}")
+          Bootable component #{component.identifier.inspect} not found
         STR
       end
     end

--- a/spec/fixtures/multiple_bootable_dirs/custom_bootables/logger.rb
+++ b/spec/fixtures/multiple_bootable_dirs/custom_bootables/logger.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Test::Container.boot(:logger) do
+  start do
+    register(:logger, "custom_logger")
+  end
+end

--- a/spec/fixtures/multiple_bootable_dirs/default_bootables/inflector.rb
+++ b/spec/fixtures/multiple_bootable_dirs/default_bootables/inflector.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Test::Container.boot(:inflector) do
+  start do
+    register(:inflector, "default_inflector")
+  end
+end

--- a/spec/fixtures/multiple_bootable_dirs/default_bootables/logger.rb
+++ b/spec/fixtures/multiple_bootable_dirs/default_bootables/logger.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Test::Container.boot(:logger) do
+  start do
+    register(:logger, "default_logger")
+  end
+end

--- a/spec/integration/container/bootable_components/multiple_bootable_dirs_spec.rb
+++ b/spec/integration/container/bootable_components/multiple_bootable_dirs_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe "Bootable components / Multiple bootable dirs" do
+  specify "Resolving boot files from multiple bootable dirs" do
+    module Test
+      class Container < Dry::System::Container
+        config.root = SPEC_ROOT.join("fixtures/multiple_bootable_dirs").realpath
+
+        config.bootable_dirs = [
+          "custom_bootables", # Relative paths are appended to the container root
+          SPEC_ROOT.join("fixtures/multiple_bootable_dirs/default_bootables")
+        ]
+      end
+    end
+
+    expect(Test::Container[:inflector]).to eq "default_inflector"
+    expect(Test::Container[:logger]).to eq "custom_logger"
+  end
+end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -191,13 +191,13 @@ RSpec.describe Dry::System::Container do
       end
     end
 
-    context "with a custom core dir" do
+    context "with a bootable dir" do
       it_behaves_like "a booted system" do
         before do
           class Test::Container < Dry::System::Container
             configure do |config|
               config.root = SPEC_ROOT.join("fixtures/other").realpath
-              config.system_dir = "config"
+              config.bootable_dirs = ["config/boot"]
             end
 
             load_paths!("lib")


### PR DESCRIPTION
This PR adds a `bootable_dirs` setting to `Dry::System::Container` and updates the `Booter` so that it finds boot files from one or more directories.

For each configured `bootable_dirs` entry, relative directories will be appended to the configured container root, and absolute directories will be left unchanged.

When searching for bootable files, the first match will win, and any subsequent same-named files will not be loaded. In this way, the bootable_dirs acts similarly to the $PATH in a shell environment.

This arrangement will support uses where a container vendor may want to ship their own “default” bootable components, but allow the _user_ of the container to replace any of them one by one. To achieve this, the user can add their own entry to the beginning of the bootable_dirs setting, which will allow their own version of the bootable components to take precedence.

---

**Notes for reviewers:**

- If you check the commit-by-commit history, you'll note I did a little tidying up before committing the actual new functionality here
- As part of adjusting the `Booter`, I also moved some truly internal methods to be under a `private` section of the class.
- I still find parts of our bootable component functionality particularly hairy, but I'll save a refactoring of those for a future PR :)