### PR TITLE
Add autoloader support, clarify load path handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-eval_gemfile 'Gemfile.devtools'
+eval_gemfile "Gemfile.devtools"
 
 gemspec
 
-gem 'bootsnap'
-gem 'dry-monitor'
+gem "bootsnap"
+gem "dry-monitor"
+gem "zeitwerk"
 
 group :tools do
-  gem 'pry-byebug', platforms: :mri
+  gem "pry-byebug", platforms: :mri
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
-gem "bootsnap"
+# Remove verson constraint once latter versions release their -java packages
+gem "bootsnap", "= 1.4.9"
 gem "dry-monitor"
 gem "zeitwerk"
 

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -93,6 +93,10 @@ module Dry
         freeze
       end
 
+      def require!
+        loader.require!
+      end
+
       # Returns components instance
       #
       # @example

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -77,6 +77,7 @@ module Dry
       setting :bootable_dirs, ["system/boot"]
       setting :registrations_dir, "container"
       setting :component_dirs, ["lib"]
+      setting :add_component_dirs_to_load_path, true
       setting :auto_register, []
       setting :inflector, Dry::Inflector.new
       setting :loader, Dry::System::Loader
@@ -401,7 +402,7 @@ module Dry
         #
         # @api public
         def add_to_load_path!(*dirs)
-          dirs.map(&root.method(:join)).each do |path|
+          dirs.reverse.map(&root.method(:join)).each do |path|
             $LOAD_PATH.prepend(path.to_s) unless $LOAD_PATH.include?(path.to_s)
           end
           self
@@ -704,6 +705,11 @@ module Dry
           container.load_component(component.identifier)
           importer.(component.namespace, container)
         end
+      end
+
+      # Default hooks
+      after :configure do
+        add_to_load_path!(*component_paths) if config.add_component_dirs_to_load_path
       end
     end
   end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -125,7 +125,6 @@ module Dry
         def configure(&block)
           hooks[:before_configure].each { |hook| instance_eval(&hook) }
           super(&block)
-          load_paths!(config.system_dir)
           hooks[:after_configure].each { |hook| instance_eval(&hook) }
           self
         end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -76,6 +76,7 @@ module Dry
       setting :system_dir, "system"
       setting :bootable_dirs, ["system/boot"]
       setting :registrations_dir, "container"
+      setting :component_dirs, ["lib"]
       setting :auto_register, []
       setting :inflector, Dry::Inflector.new
       setting :loader, Dry::System::Loader
@@ -553,8 +554,8 @@ module Dry
         end
 
         # @api private
-        def load_paths
-          @load_paths ||= []
+        def component_paths
+          config.component_dirs.map(&root.method(:join))
         end
 
         # @api private
@@ -610,7 +611,7 @@ module Dry
         def require_component(component)
           return if registered?(component.identifier)
 
-          raise FileNotFoundError, component unless component.file_exists?(load_paths)
+          raise FileNotFoundError, component unless component.file_exists?(component_paths)
 
           require_path(component.path)
 
@@ -683,7 +684,7 @@ module Dry
 
         # @api private
         def load_local_component(component, default_namespace_fallback = false, &block)
-          if booter.bootable?(component) || component.file_exists?(load_paths)
+          if booter.bootable?(component) || component.file_exists?(component_paths)
             booter.boot_dependency(component) unless finalized?
 
             require_component(component) do

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -668,15 +668,12 @@ module Dry
 
         # @api private
         def inherited(klass)
-          new_hooks = Container.hooks.dup
-
           hooks.each do |event, blocks|
-            new_hooks[event].concat(blocks)
-            new_hooks[event].concat(klass.hooks[event])
+            klass.hooks[event].concat blocks.dup
           end
 
-          klass.instance_variable_set(:@hooks, new_hooks)
           klass.instance_variable_set(:@__finalized__, false)
+
           super
         end
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -614,20 +614,9 @@ module Dry
 
           raise FileNotFoundError, component unless component.file_exists?(component_paths)
 
-          require_path(component.path)
+          component.require!
 
           yield
-        end
-
-        # Allows subclasses to use a different strategy for required files.
-        #
-        # E.g. apps that use `ActiveSupport::Dependencies::Loadable#require_dependency`
-        # will override this method to allow container managed dependencies to be reloaded
-        # for non-finalized containers.
-        #
-        # @api private
-        def require_path(path)
-          require path
         end
 
         # @api private

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -61,7 +61,7 @@ module Dry
     #     end
     #
     #     # this will configure $LOAD_PATH to include your `lib` dir
-    #     load_paths!('lib')
+    #     add_dirs_to_load_paths!('lib')
     #   end
     #
     # @api public
@@ -384,7 +384,7 @@ module Dry
           self
         end
 
-        # Sets load paths relative to the container's root dir
+        # Adds the directories (relative to the container's root) to the Ruby load path
         #
         # @example
         #   class MyApp < Dry::System::Container
@@ -392,7 +392,7 @@ module Dry
         #       # ...
         #     end
         #
-        #     load_paths!('lib')
+        #     add_to_load_path!('lib')
         #   end
         #
         # @param [Array<String>] dirs
@@ -400,12 +400,9 @@ module Dry
         # @return [self]
         #
         # @api public
-        def load_paths!(*dirs)
+        def add_to_load_path!(*dirs)
           dirs.map(&root.method(:join)).each do |path|
-            next if load_paths.include?(path)
-
-            load_paths << path
-            $LOAD_PATH.unshift(path.to_s)
+            $LOAD_PATH.prepend(path.to_s) unless $LOAD_PATH.include?(path.to_s)
           end
           self
         end

--- a/lib/dry/system/loader.rb
+++ b/lib/dry/system/loader.rb
@@ -39,6 +39,14 @@ module Dry
         @inflector = inflector
       end
 
+      # Require the component's source file
+      #
+      # @api public
+      def require!
+        require path
+        self
+      end
+
       # Returns component's instance
       #
       # Provided optional args are passed to object's constructor

--- a/lib/dry/system/loader/autoloading.rb
+++ b/lib/dry/system/loader/autoloading.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../loader"
+
+module Dry
+  module System
+    class Loader
+      # Component loader for autoloading-enabled applications
+      #
+      # This behaves like the default loader, except instead of requiring the given path,
+      # it loads the respective constant, allowing the autoloader to load the
+      # corresponding file per its own configuration.
+      #
+      # @see Loader
+      # @api public
+      class Autoloading < Loader
+        def require!
+          constant
+          self
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/autoloading/lib/test/entities/foo_entity.rb
+++ b/spec/fixtures/autoloading/lib/test/entities/foo_entity.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Test
+  module Entities
+    class FooEntity
+    end
+  end
+end

--- a/spec/fixtures/autoloading/lib/test/foo.rb
+++ b/spec/fixtures/autoloading/lib/test/foo.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Test
+  class Foo
+    def call
+      Entities::FooEntity.new
+    end
+  end
+end

--- a/spec/integration/container/autoloading_spec.rb
+++ b/spec/integration/container/autoloading_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "dry/system/container"
+require "dry/system/loader/autoloading"
+require "zeitwerk"
+
+RSpec.describe "Autoloading loader" do
+  specify "Resolves components using Zeitwerk" do
+    # See https://github.com/jruby/jruby/issues/5638 for current state
+    pending "Zeitwerk is not fully functioning on JRuby" if RUBY_PLATFORM == "java"
+
+    module Test
+      class Container < Dry::System::Container
+        config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
+        config.add_component_dirs_to_load_path = false
+        config.loader = Dry::System::Loader::Autoloading
+        config.default_namespace = "test"
+      end
+    end
+
+    loader = Zeitwerk::Loader.new
+    loader.push_dir Test::Container.config.root.join("lib").realpath
+    loader.setup
+
+    foo = Test::Container["foo"]
+    entity = foo.call
+
+    expect(foo).to be_a Test::Foo
+    expect(entity).to be_a Test::Entities::FooEntity
+
+    teardown_zeitwerk
+  end
+
+  def teardown_zeitwerk
+    # From zeitwerk's own test/support/loader_test
+
+    Zeitwerk::Registry.loaders.each(&:unload)
+
+    Zeitwerk::Registry.loaders.clear
+    Zeitwerk::Registry.loaders_managing_gems.clear
+
+    Zeitwerk::ExplicitNamespace.cpaths.clear
+    Zeitwerk::ExplicitNamespace.tracer.disable
+  end
+end

--- a/spec/integration/container/lazy_loading/bootable_components_spec.rb
+++ b/spec/integration/container/lazy_loading/bootable_components_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Lazy loading bootable components" do
             config.root = SPEC_ROOT.join("fixtures/lazy_loading/shared_root_keys").realpath
           end
 
-          load_paths! "lib"
+          add_to_load_path! "lib"
         end
       end
     end

--- a/spec/integration/container/lazy_loading/manual_registration_spec.rb
+++ b/spec/integration/container/lazy_loading/manual_registration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Lazy-loading manual registration files" do
           config.root = SPEC_ROOT.join("fixtures/manual_registration").realpath
         end
 
-        load_paths!("lib")
+        add_to_load_path!("lib")
       end
     end
   end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
           config.root = SPEC_ROOT.join("fixtures").realpath
         end
 
-        load_paths!("components")
+        add_to_load_path!("components")
         auto_register!("components")
       end
     end
@@ -34,9 +34,10 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs = ["components"]
         end
 
-        load_paths!("components")
+        add_to_load_path!("components")
       end
     end
 
@@ -63,7 +64,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
           config.root = SPEC_ROOT.join("fixtures").realpath
         end
 
-        load_paths!("components")
+        add_to_load_path!("components")
       end
     end
 
@@ -108,7 +109,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
           config.default_namespace = "namespaced"
         end
 
-        load_paths!("namespaced_components")
+        add_to_load_path!("namespaced_components")
         auto_register!("namespaced_components")
       end
     end
@@ -126,7 +127,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
           config.default_namespace = "namespace"
         end
 
-        load_paths!("components")
+        add_to_load_path!("components")
         auto_register!("components")
       end
     end
@@ -144,7 +145,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
           config.default_namespace = "multiple.level"
         end
 
-        load_paths!("multiple_namespaced_components")
+        add_to_load_path!("multiple_namespaced_components")
         auto_register!("multiple_namespaced_components")
       end
     end
@@ -167,7 +168,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
           config.loader = ::Test::Loader
         end
 
-        load_paths!("components")
+        add_to_load_path!("components")
         auto_register!("components")
       end
     end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs = ["components"]
         end
 
         add_to_load_path!("components")
@@ -62,6 +63,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       Class.new(Dry::System::Container) do
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs = ["components"]
         end
 
         add_to_load_path!("components")
@@ -106,6 +108,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs = ["namespaced_components"]
           config.default_namespace = "namespaced"
         end
 
@@ -124,6 +127,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs = ["components"]
           config.default_namespace = "namespace"
         end
 
@@ -142,6 +146,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs = ["multiple_namespaced_components"]
           config.default_namespace = "multiple.level"
         end
 
@@ -165,6 +170,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs = ["components"]
           config.loader = ::Test::Loader
         end
 
@@ -185,6 +191,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
         class Test::Container < Dry::System::Container
           configure do |config|
             config.root = SPEC_ROOT.join("fixtures").realpath
+            config.component_dirs = ["components"]
             config.auto_register = %w[unknown_dir]
           end
         end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -3,7 +3,7 @@
 require "dry/system/container"
 
 RSpec.describe Dry::System::Container, ".auto_register!" do
-  before do
+  after do
     Object.send(:remove_const, :Foo) if defined? Foo
     Object.send(:remove_const, :Bar) if defined? Bar
   end

--- a/spec/unit/container/hooks/load_path_hook_spec.rb
+++ b/spec/unit/container/hooks/load_path_hook_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::System::Container, "Default hooks / Load path" do
+  let(:container) {
+    Class.new(Dry::System::Container) {
+      config.root = SPEC_ROOT.join("fixtures/test")
+      config.component_dirs = ["lib"]
+    }
+  }
+
+  before do
+    @load_path_before = $LOAD_PATH
+  end
+
+  after do
+    $LOAD_PATH.replace(@load_path_before)
+  end
+
+  context "add_component_dirs_to_load_path is true" do
+    before do
+      container.config.add_component_dirs_to_load_path = true
+    end
+
+    it "adds the component dirs to the load path" do
+      expect { container.configure do; end }
+        .to change { $LOAD_PATH.include?(SPEC_ROOT.join("fixtures/test/lib").to_s) }
+        .from(false).to(true)
+    end
+  end
+
+  context "add_component_dirs_to_load_path is true" do
+    before do
+      container.config.add_component_dirs_to_load_path = false
+    end
+
+    it "does not change the load path" do
+      expect { container.configure do; end }.not_to(change { $LOAD_PATH })
+    end
+  end
+end

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Dry::System::Container, ".import" do
           config.root = SPEC_ROOT.join("fixtures/import_test").realpath
         end
 
-        load_paths!("lib")
+        add_to_load_path!("lib")
       end
 
       class Test::Container < Dry::System::Container
@@ -36,7 +36,7 @@ RSpec.describe Dry::System::Container, ".import" do
           config.root = SPEC_ROOT.join("fixtures/test").realpath
         end
 
-        load_paths!("lib")
+        add_to_load_path!("lib")
 
         import other: Test::Other
       end

--- a/spec/unit/container/load_path_spec.rb
+++ b/spec/unit/container/load_path_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "dry/system/container"
+
+RSpec.describe Dry::System::Container, "Load path handling" do
+  let(:container) {
+    class Test::Container < Dry::System::Container
+      config.root = SPEC_ROOT.join("fixtures/test")
+      config.component_dirs = ["lib"]
+    end
+
+    Test::Container
+  }
+
+  before do
+    @load_path_before = $LOAD_PATH
+  end
+
+  after do
+    $LOAD_PATH.replace(@load_path_before)
+  end
+
+  describe ".add_to_load_path!" do
+    it "adds the given directories, relative to the container's root, to the beginning of the $LOAD_PATH" do
+      expect { container.add_to_load_path!("lib", "system") }
+        .to change { $LOAD_PATH.include?(SPEC_ROOT.join("fixtures/test/lib").to_s) }
+        .from(false).to(true)
+        .and change { $LOAD_PATH.include?(SPEC_ROOT.join("fixtures/test/system").to_s) }
+        .from(false).to(true)
+
+      expect($LOAD_PATH[0..1]).to eq [
+        SPEC_ROOT.join("fixtures/test/lib").to_s,
+        SPEC_ROOT.join("fixtures/test/system").to_s
+      ]
+    end
+  end
+end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -100,35 +100,6 @@ RSpec.describe Dry::System::Container do
         expect { container.load_component("test.no_matching_file") }.not_to raise_error
       end
     end
-
-    describe ".require_path" do
-      before do
-        module Test
-          class FileLoader
-          end
-
-          class Container < Dry::System::Container
-            configure do |config|
-              config.root = SPEC_ROOT.join("fixtures/require_path").realpath
-            end
-
-            add_to_load_path!("lib")
-
-            class << self
-              def require_path(path)
-                Test::FileLoader.(path)
-              end
-            end
-          end
-        end
-      end
-
-      it "defines an extension point for subclasses to use alternatives to Kernel#require" do
-        expect(Test::FileLoader).to receive(:call).with("test/foo").and_return(true)
-
-        container.load_component("test.foo")
-      end
-    end
   end
 
   describe ".init" do

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dry::System::Container do
           config.root = SPEC_ROOT.join("fixtures/test").realpath
         end
 
-        load_paths!("lib")
+        add_to_load_path!("lib")
       end
 
       module Test
@@ -112,7 +112,7 @@ RSpec.describe Dry::System::Container do
               config.root = SPEC_ROOT.join("fixtures/require_path").realpath
             end
 
-            load_paths!("lib")
+            add_to_load_path!("lib")
 
             class << self
               def require_path(path)
@@ -138,7 +138,7 @@ RSpec.describe Dry::System::Container do
           config.root = SPEC_ROOT.join("fixtures/lazytest").realpath
         end
 
-        load_paths!("lib")
+        add_to_load_path!("lib")
       end
     end
 
@@ -185,7 +185,7 @@ RSpec.describe Dry::System::Container do
               config.root = SPEC_ROOT.join("fixtures/test").realpath
             end
 
-            load_paths!("lib")
+            add_to_load_path!("lib")
           end
         end
       end
@@ -200,7 +200,7 @@ RSpec.describe Dry::System::Container do
               config.bootable_dirs = ["config/boot"]
             end
 
-            load_paths!("lib")
+            add_to_load_path!("lib")
           end
         end
       end
@@ -218,7 +218,7 @@ RSpec.describe Dry::System::Container do
           config.root = SPEC_ROOT.join("fixtures/stubbing").realpath
         end
 
-        load_paths!("lib")
+        add_to_load_path!("lib")
         auto_register!("lib")
       end
     end
@@ -262,7 +262,7 @@ RSpec.describe Dry::System::Container do
 
       class Test::Container < Dry::System::Container
         config.root = SPEC_ROOT.join("fixtures/test").realpath
-        load_paths!("lib")
+        add_to_load_path!("lib")
 
         importer.registry.update(falses: Test::FalseyContainer)
       end
@@ -298,7 +298,7 @@ RSpec.describe Dry::System::Container do
     before do
       class Test::Container < Dry::System::Container
         config.root = SPEC_ROOT.join("fixtures/test").realpath
-        load_paths!("lib")
+        add_to_load_path!("lib")
       end
     end
 

--- a/spec/unit/loader/autoloading_spec.rb
+++ b/spec/unit/loader/autoloading_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "dry/system/loader/autoloading"
+
+RSpec.describe Dry::System::Loader::Autoloading do
+  describe "#require!" do
+    subject(:loader) { described_class.new("test/not_loaded_const") }
+
+    before do
+      allow(loader).to receive(:require)
+      allow(Test).to receive(:const_missing)
+    end
+
+    it "loads the constant " do
+      loader.require!
+      expect(loader).not_to have_received(:require)
+      expect(Test).to have_received(:const_missing).with :NotLoadedConst
+    end
+
+    it "returns self" do
+      expect(loader.require!).to eql loader
+    end
+  end
+end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -4,78 +4,97 @@ require "dry/inflector"
 require "dry/system/loader"
 require "singleton"
 
-RSpec.describe Dry::System::Loader, "#call" do
-  shared_examples_for "object loader" do
-    let(:instance) { loader.call }
-
-    context "not singleton" do
-      it "returns a new instance of the constant" do
-        expect(instance).to be_instance_of(constant)
-        expect(instance).not_to be(loader.call)
-      end
-    end
-
-    context "singleton" do
-      before { constant.send(:include, Singleton) }
-
-      it "returns singleton instance" do
-        expect(instance).to be(constant.instance)
-      end
-    end
-  end
-
-  context "with a singular name" do
-    subject(:loader) { Dry::System::Loader.new("test/bar") }
-
-    let(:constant) { Test::Bar }
-
-    before do
-      module Test; class Bar; end; end
-    end
-
-    it_behaves_like "object loader"
-  end
-
-  context "with a plural name" do
-    subject(:loader) { Dry::System::Loader.new("test/bars") }
-
-    let(:constant) { Test::Bars }
-
-    before do
-      module Test; class Bars; end; end
-    end
-
-    it_behaves_like "object loader"
-  end
-
-  context "with a constructor accepting args" do
+RSpec.describe Dry::System::Loader do
+  describe "#require!" do
     subject(:loader) { Dry::System::Loader.new("test/bar") }
 
     before do
-      module Test
-        Bar = Struct.new(:one, :two)
-      end
+      allow(loader).to receive(:require)
     end
 
-    it "passes args to the constructor" do
-      instance = loader.call(1, 2)
+    it "requires the loader's path" do
+      loader.require!
+      expect(loader).to have_received(:require).with "test/bar"
+    end
 
-      expect(instance.one).to be(1)
-      expect(instance.two).to be(2)
+    it "returns self" do
+      expect(loader.require!).to eql loader
     end
   end
 
-  context "with a custom inflector" do
-    let(:inflector) { Dry::Inflector.new { |i| i.acronym("API") } }
+  describe "#call" do
+    shared_examples_for "object loader" do
+      let(:instance) { loader.call }
 
-    subject(:loader) { Dry::System::Loader.new("test/api_bar", inflector) }
+      context "not singleton" do
+        it "returns a new instance of the constant" do
+          expect(instance).to be_instance_of(constant)
+          expect(instance).not_to be(loader.call)
+        end
+      end
 
-    let(:constant) { Test::APIBar }
+      context "singleton" do
+        before { constant.send(:include, Singleton) }
 
-    before do
-      Test::APIBar = Class.new
+        it "returns singleton instance" do
+          expect(instance).to be(constant.instance)
+        end
+      end
     end
 
-    it_behaves_like "object loader"
+    context "with a singular name" do
+      subject(:loader) { Dry::System::Loader.new("test/bar") }
+
+      let(:constant) { Test::Bar }
+
+      before do
+        module Test; class Bar; end; end
+      end
+
+      it_behaves_like "object loader"
+    end
+
+    context "with a plural name" do
+      subject(:loader) { Dry::System::Loader.new("test/bars") }
+
+      let(:constant) { Test::Bars }
+
+      before do
+        module Test; class Bars; end; end
+      end
+
+      it_behaves_like "object loader"
+    end
+
+    context "with a constructor accepting args" do
+      subject(:loader) { Dry::System::Loader.new("test/bar") }
+
+      before do
+        module Test
+          Bar = Struct.new(:one, :two)
+        end
+      end
+
+      it "passes args to the constructor" do
+        instance = loader.call(1, 2)
+
+        expect(instance.one).to be(1)
+        expect(instance.two).to be(2)
+      end
+    end
+
+    context "with a custom inflector" do
+      let(:inflector) { Dry::Inflector.new { |i| i.acronym("API") } }
+
+      subject(:loader) { Dry::System::Loader.new("test/api_bar", inflector) }
+
+      let(:constant) { Test::APIBar }
+
+      before do
+        Test::APIBar = Class.new
+      end
+
+      it_behaves_like "object loader"
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for working with autoloaders like [Zeitwerk](http://github.com/fxn/zeitwerk).

It achieves this by:

- Moving the responsibility for requiring files away from `Container` (removing `.require_path`, **a breaking change**) and into the `Component` (as `Component#require!`), which itself delegates to the configured `Loader` (via `Loader#require!)
- Adding a new `Dry::System::Loader::Autoloading` loader, which can be configured to replace the default loader. This is identical to the default loader except that instead of requiring the component's file, it accesses the component's constant, which is a sufficient trigger for an autoloader like Zeitwerk to load the constant based on its own configuration

Along with this, it makes some internal changes and to rationalise some related underpinnings:

- Renames `Container.load_paths!` to `.add_to_load_path!`, to make its function much clearer (**this is a breaking change**)
- Stops automatically adding the `system_dir` to the load path, since its now a reasonable use case to run dry-system without any of its managed directories being on the load path (**this is a breaking behavioural change**)
- Adds a new `component_dirs` setting, defaulting to `["lib"]`, which is used to verify whether a given component is "local" to the container. This check was previously done using the directories previously passed to `load_paths!`, which we can't rely upon now that we're supporting autoloaders.
- Adds a new `add_component_dirs_to_load_path` setting, defaulting to `true`, which will automatically add the configured `component_dirs` to the load path in an after-configure hook. This will help ease the transition from the previous behaviour, and make dry-system still work nicely when _not_ using an autoloader.

To see this all in action, check out the integration test using Zeitwerk: `spec/integration/container/autoloading_spec.rb`. 

Here's the highlights, for easy reference. Container setup:

```ruby
module Test
  class Container < Dry::System::Container
    config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
    config.add_component_dirs_to_load_path = false
    config.loader = Dry::System::Loader::Autoloading
    config.default_namespace = "test"
  end
end
```

Zeitwerk setup:

```ruby
loader = Zeitwerk::Loader.new
loader.push_dir Test::Container.config.root.join("lib").realpath
loader.setup
```

Then given a component "foo", at `lib/test/foo.rb`:

```ruby
module Test
  class Foo
    def call
      # Referencing this constant without a require!
      Entities::FooEntity.new
    end
  end
end
```

Resolving `Test::Container["foo"]` will give you an instance of `Test::Foo` as expected, and then a `#call` will also return an `Entities::FooEntity` as expected. Too easy!

---

This PR is the first step of several. The next step will be to add a "rich configuration" API for adding component dirs, and allowing auto-registration to be enabled/disabled/configured independently for each component dir. With this in place, we can then remove the `auto_register` setting (which no longer makes sense as an independent setting, since the auto-registrar should _only_ be operating on component dirs), as well as the `auto_register!` method (for the same reasons).

A further step could be to add a `zeitwerk` _plugin_ to dry-system (just like how we have a `bootsnap` plugin) that takes care of setting up the zeitwerk loader for the configured component dirs, as well as configuring the autoloading loader, which would give dry-system users a simple one-line way to enable zeitwerk!

At this point (or perhaps before doing the plugin) I'll switch back to Hanami and work on configuring its container to work with zeitwerk, which will be a useful check to ensure this new arrangement in dry-system is offering everything we need. Once that is done, I think we can work on cutting a new dry-system release. (This will also need some coordination with dry-rails to make sure we don't break it)

Time-wise, I hope to get most of this done across the month of November.