### PR TITLE
Add rich component dirs config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,10 @@ Layout/LineLength:
 Lint/BooleanSymbol:
   Enabled: false
 
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - "spec/**/*_spec.rb"
+
 Lint/RaiseException:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
+gem "dry-configurable", git: "https://github.com/dry-rb/dry-configurable", branch: "master"
+
 # Remove verson constraint once latter versions release their -java packages
 gem "bootsnap", "= 1.4.9"
 gem "dry-monitor"

--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -26,7 +26,9 @@ module Dry
 
       # @api private
       def finalize!
-        Array(config.auto_register).each { |dir| call(dir) }
+        config.component_dirs.each do |dir|
+          call(dir.path) if dir.auto_register
+        end
       end
 
       # @api private
@@ -36,11 +38,9 @@ module Dry
         components(dir).each do |component|
           next if !component.auto_register? || registration_config.exclude.(component)
 
-          container.require_component(component) do
-            register(component.identifier, memoize: registration_config.memoize) {
-              registration_config.instance.(component)
-            }
-          end
+          register(component.identifier, memoize: registration_config.memoize) {
+            registration_config.instance.(component)
+          }
         end
       end
 

--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -3,6 +3,7 @@
 require "dry/system/constants"
 require "dry/system/magic_comments_parser"
 require "dry/system/auto_registrar/configuration"
+require_relative "component"
 
 module Dry
   module System
@@ -34,11 +35,13 @@ module Dry
       # @api private
       def call(dir)
         registration_config = Configuration.new
-        yield(registration_config) if block_given?
-        components(dir).each do |component|
-          next if !component.auto_register? || registration_config.exclude.(component)
 
-          register(component.identifier, memoize: registration_config.memoize) {
+        yield(registration_config) if block_given?
+
+        components(dir).each do |component|
+          next unless register_component?(component, registration_config)
+
+          container.register(component.identifier, memoize: registration_config.memoize) {
             registration_config.instance.(component)
           }
         end
@@ -46,17 +49,18 @@ module Dry
 
       private
 
-      # @api private
       def components(dir)
-        files(dir)
-          .map { |file_name| [file_name, file_options(file_name)] }
-          .map { |file_name, options| component(relative_path(dir, file_name), **options) }
-          .reject { |component| registered?(component.identifier) }
+        files(dir).map { |file_name|
+          Component.new(
+            relative_path(dir, file_name),
+            file_path: file_name,
+            **MagicCommentsParser.(file_name)
+          )
+        }
       end
 
-      # @api private
       def files(dir)
-        components_dir = File.join(root, dir)
+        components_dir = File.join(container.root, dir)
 
         unless ::Dir.exist?(components_dir)
           raise ComponentsDirMissing, "Components dir '#{components_dir}' not found"
@@ -65,35 +69,15 @@ module Dry
         ::Dir["#{components_dir}/**/#{RB_GLOB}"].sort
       end
 
-      # @api private
       def relative_path(dir, file_path)
-        dir_root = root.join(dir.to_s.split("/")[0])
+        dir_root = container.root.join(dir.to_s.split("/")[0])
         file_path.to_s.sub("#{dir_root}/", "").sub(RB_EXT, EMPTY_STRING)
       end
 
-      # @api private
-      def file_options(file_name)
-        MagicCommentsParser.(file_name)
-      end
-
-      # @api private
-      def component(path, **options)
-        container.component(path, **options)
-      end
-
-      # @api private
-      def root
-        container.root
-      end
-
-      # @api private
-      def registered?(name)
-        container.registered?(name)
-      end
-
-      # @api private
-      def register(*args, &block)
-        container.register(*args, &block)
+      def register_component?(component, registration_config)
+        !container.registered?(component) &&
+          component.auto_register? &&
+          !registration_config.exclude.(component)
       end
     end
   end

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -41,6 +41,20 @@ module Dry
         self
       end
 
+      # Returns a bootable component if it can be found or loaded, otherwise nil
+      #
+      # @return [Dry::System::Components::Bootable, nil]
+      # @api private
+      def find_component(identifier)
+        return components[identifier] if components.exists?(identifier)
+
+        return if finalized?
+
+        require_boot_file(identifier)
+
+        components[identifier] if components.exists?(identifier)
+      end
+
       # @api private
       def finalize!
         boot_files.each do |path|
@@ -53,6 +67,13 @@ module Dry
 
         freeze
       end
+
+      # @!method finalized?
+      #   Returns true if the booter has been finalized
+      #
+      #   @return [Boolean]
+      #   @api private
+      alias_method :finalized?, :frozen?
 
       # @api private
       def shutdown
@@ -168,9 +189,10 @@ module Dry
         self
       end
 
+      # TODO: this name should reflect we're doing a root_key check
+      # TODO: find out in what situations we're actually passing something with a .root_key
       def boot_file(name)
         name = name.respond_to?(:root_key) ? name.root_key.to_s : name
-
         find_boot_file(name)
       end
 

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -31,11 +31,6 @@ module Dry
       end
 
       # @api private
-      def bootable?(component)
-        !boot_file(component).nil?
-      end
-
-      # @api private
       def register_component(component)
         components.register(component)
         self
@@ -136,9 +131,11 @@ module Dry
 
       # @api private
       def boot_dependency(component)
-        boot_file = boot_file(component)
+        name = component.respond_to?(:root_key) ? component.root_key : component.to_sym
 
-        start(boot_file.basename(".*").to_s.to_sym) if boot_file
+        if (component = find_component(name))
+          start(component)
+        end
       end
 
       # Returns all boot files within the configured paths
@@ -187,13 +184,6 @@ module Dry
         Kernel.require path unless components.exists?(identifier)
 
         self
-      end
-
-      # TODO: this name should reflect we're doing a root_key check
-      # TODO: find out in what situations we're actually passing something with a .root_key
-      def boot_file(name)
-        name = name.respond_to?(:root_key) ? name.root_key.to_s : name
-        find_boot_file(name)
       end
 
       def require_boot_file(identifier)

--- a/lib/dry/system/booter.rb
+++ b/lib/dry/system/booter.rb
@@ -120,7 +120,14 @@ module Dry
         start(boot_file.basename(".*").to_s.to_sym) if boot_file
       end
 
-      # @api private
+      # Returns all boot files within the configured paths
+      #
+      # Searches for files in the order of the configured paths. In the case of multiple
+      # identically-named boot files within different paths, the file found first will be
+      # returned, and other matching files will be discarded.
+      #
+      # @return [Array<Pathname>]
+      # @api public
       def boot_files
         @boot_files ||= paths.each_with_object([[], []]) { |path, (boot_files, loaded)|
           files = Dir["#{path}/#{RB_GLOB}"].sort

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -7,6 +7,7 @@ require "dry/inflector"
 require "dry/system/loader"
 require "dry/system/errors"
 require "dry/system/constants"
+require "dry/system/magic_comments_parser"
 
 module Dry
   module System
@@ -64,14 +65,14 @@ module Dry
           end
         }
 
-        # TODO: read options from magic comments at top of file? that's what the
-        # auto-registrar does (or maybe we should be doing that in Container.component?)
+        file_options = found_path ? MagicCommentsParser.(found_path) : EMPTY_HASH
 
         new(
           identifier,
           namespace: found_namespace,
           file_path: found_path,
-          **options
+          **file_options,
+          **options,
         )
       end
 

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -53,10 +53,10 @@ module Dry
           name, options = args
           options = DEFAULT_OPTIONS.merge(options || EMPTY_HASH)
 
-          ns, sep, inflector = options.values_at(:namespace, :separator, :inflector)
-          identifier = extract_identifier(name, ns, sep)
+          namespace, separator, inflector = options.values_at(:namespace, :separator, :inflector)
+          identifier = extract_identifier(name, namespace, separator)
 
-          path = name.to_s.gsub(sep, PATH_SEPARATOR)
+          path = name.to_s.gsub(separator, PATH_SEPARATOR)
           loader = options.fetch(:loader, Loader).new(path, inflector)
 
           super(identifier, path, options.merge(loader: loader))
@@ -64,16 +64,17 @@ module Dry
       end
 
       # @api private
-      def self.extract_identifier(name, ns, sep)
-        name_s = name.to_s
-        identifier = ns ? remove_namespace_from_name(name_s, ns) : name_s
+      def self.extract_identifier(name, namespace, separator)
+        name = name.to_s
 
-        identifier.scan(WORD_REGEX).join(sep)
+        identifier = namespace ? remove_namespace_from_name(name, namespace) : name
+
+        identifier.scan(WORD_REGEX).join(separator)
       end
 
       # @api private
-      def self.remove_namespace_from_name(name, ns)
-        match_value = name.match(/^(?<remove_namespace>#{ns})(?<separator>\W)(?<identifier>.*)/)
+      def self.remove_namespace_from_name(name, namespace)
+        match_value = name.match(/^(?<remove_namespace>#{namespace})(?<separator>\W)(?<identifier>.*)/)
 
         match_value ? match_value[:identifier] : name
       end

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -54,7 +54,7 @@ module Dry
       #
       # @return [Dry::System::Component]
       # @api private
-      def self.locate(identifier, component_dirs, **options)
+      def self.locate(identifier, component_dirs, options = EMPTY_HASH)
         options = DEFAULT_OPTIONS.merge(options)
 
         path = identifier.to_s.gsub(options[:separator], PATH_SEPARATOR)
@@ -77,7 +77,7 @@ module Dry
       end
 
       # @api private
-      def self.new(identifier, **options)
+      def self.new(identifier, options = EMPTY_HASH)
         options = DEFAULT_OPTIONS.merge(options)
 
         namespace, separator = options.values_at(:namespace, :separator)

--- a/lib/dry/system/component_dir.rb
+++ b/lib/dry/system/component_dir.rb
@@ -1,0 +1,68 @@
+require "pathname"
+require_relative "constants"
+
+module Dry
+  module System
+    # A configured component directory within the container's root. Provides access to the
+    # component directory's configuration, as well as methods for locating component files
+    # within the directory
+    #
+    # @see Dry::System::Config::ComponentDir
+    # @api private
+    class ComponentDir
+      # @!attribute [r] config
+      #   @return [Dry::System::Config::ComponentDir] the component directory configuration
+      #   @api private
+      attr_reader :config
+
+      # @!attribute [r] root
+      #   @return [Pathname] the configured root directory
+      #   @see Dry::System::Container#root
+      #   @api private
+      attr_reader :root
+
+      # @api private
+      def initialize(config:, root:)
+        @root = Pathname(root)
+        @config = config
+      end
+
+      # Returns the full path of the component directory
+      #
+      # @return [Pathname]
+      # @api private
+      def full_path
+        root.join(path)
+      end
+
+      # Returns the full path for a component file within the directory, or nil if none if
+      # exists
+      #
+      # @return [Pathname, nil]
+      # @api private
+      def component_file(component_path)
+        if default_namespace
+          namespace_path = default_namespace.gsub(DEFAULT_SEPARATOR, PATH_SEPARATOR)
+          component_path = "#{namespace_path}#{PATH_SEPARATOR}#{component_path}"
+        end
+
+        component_file = full_path.join("#{component_path}#{RB_EXT}")
+        component_file if component_file.exist?
+      end
+
+      private
+
+      def method_missing(name, *args, &block)
+        if config.respond_to?(name)
+          config.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, include_all = false)
+        config.respond_to?(name) || super
+      end
+    end
+  end
+end

--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -1,0 +1,37 @@
+require "dry/configurable"
+
+module Dry
+  module System
+    module Config
+      class ComponentDir
+        include Dry::Configurable
+
+        setting :auto_register, true
+        setting :add_to_load_path, true
+        setting :default_namespace
+
+        attr_reader :path
+
+        def initialize(path)
+          super()
+          @path = path
+          yield self if block_given?
+        end
+
+        private
+
+        def method_missing(name, *args, &block)
+          if config.respond_to?(name)
+            config.public_send(name, *args, &block)
+          else
+            super
+          end
+        end
+
+        def respond_to_missing?(name, include_all = false)
+          config.respond_to?(name) || super
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -1,0 +1,51 @@
+require "concurrent/map"
+require "dry/configurable"
+require "dry/system/errors"
+require_relative "component_dir"
+
+module Dry
+  module System
+    module Config
+      class ComponentDirs
+        attr_reader :dirs
+
+        def initialize
+          @dirs = Concurrent::Map.new
+        end
+
+        def initialize_copy(source)
+          super
+          @dirs = source.dirs.dup
+        end
+
+        def add(path_or_component_dir, &block)
+          if path_or_component_dir.is_a?(ComponentDir)
+            add_component_dir(path_or_component_dir)
+          else
+            build_and_add_component_dir(path_or_component_dir, &block)
+          end
+        end
+
+        def to_a
+          dirs.values
+        end
+
+        def each(&block)
+          to_a.each(&block)
+        end
+
+        private
+
+        def build_and_add_component_dir(path, &block)
+          add_component_dir(ComponentDir.new(path, &block))
+        end
+
+        def add_component_dir(dir)
+          raise ComponentDirAlreadyAddedError(dir.path) if dirs.key?(dir.path)
+
+          dirs[dir.path] = dir
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -642,6 +642,8 @@ module Dry
           component(key).tap do |component|
             if component.bootable?
               booter.start(component)
+            elsif !component.auto_register?
+              raise ComponentLoadError, component
             else
               root_key = component.root_key
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -20,6 +20,9 @@ require "dry/system/component"
 require "dry/system/constants"
 require "dry/system/plugins"
 
+require_relative "component_dir"
+require_relative "config/component_dirs"
+
 module Dry
   module System
     # Abstract container class to inherit from
@@ -71,14 +74,11 @@ module Dry
       extend Dry::System::Plugins
 
       setting :name
-      setting :default_namespace
       setting(:root, Pathname.pwd.freeze) { |path| Pathname(path) }
       setting :system_dir, "system"
       setting :bootable_dirs, ["system/boot"]
       setting :registrations_dir, "container"
-      setting :component_dirs, ["lib"]
-      setting :add_component_dirs_to_load_path, true
-      setting :auto_register, []
+      setting :component_dirs, Config::ComponentDirs.new, cloneable: true
       setting :inflector, Dry::Inflector.new
       setting :loader, Dry::System::Loader
       setting :booter, Dry::System::Booter
@@ -555,8 +555,8 @@ module Dry
         end
 
         # @api private
-        def component_paths
-          config.component_dirs.map(&root.method(:join))
+        def component_dirs
+          config.component_dirs.to_a.map { |dir| ComponentDir.new(config: dir, root: root) }
         end
 
         # @api private
@@ -594,52 +594,18 @@ module Dry
 
         # @api private
         def component(identifier, **options)
-          if (component = booter.components.detect { |c| c.identifier == identifier })
-            component
-          else
-            Component.new(
-              identifier,
-              loader: config.loader,
-              namespace: config.default_namespace,
-              separator: config.namespace_separator,
-              inflector: config.inflector,
-              **options
-            )
-          end
-        end
-
-        # @api private
-        def require_component(component)
-          return if registered?(component.identifier)
-
-          raise FileNotFoundError, component unless component.file_exists?(component_paths)
-
-          component.require!
-
-          yield
-        end
-
-        # @api private
-        def load_component(key, &block)
-          return self if registered?(key)
-
-          component(key).tap do |component|
-            if component.bootable?
-              booter.start(component)
-            else
-              root_key = component.root_key
-
-              if (root_bootable = component(root_key)).bootable?
-                booter.start(root_bootable)
-              elsif importer.key?(root_key)
-                load_imported_component(component.namespaced(root_key))
-              end
-
-              load_local_component(component, &block) unless registered?(key)
-            end
+          if (bootable_component = booter.find_component(identifier))
+            return bootable_component
           end
 
-          self
+          Component.locate(
+            identifier,
+            component_dirs,
+            loader: config.loader,
+            separator: config.namespace_separator,
+            inflector: config.inflector,
+            **options
+          )
         end
 
         # @api private
@@ -667,18 +633,39 @@ module Dry
           super
         end
 
+        protected
+
+        # @api private
+        def load_component(key, &block)
+          return self if registered?(key)
+
+          component(key).tap do |component|
+            if component.bootable?
+              booter.start(component)
+            else
+              root_key = component.root_key
+
+              if (root_bootable = component(root_key)).bootable?
+                booter.start(root_bootable)
+              elsif importer.key?(root_key) && !component.file_exists? # TODO: need tests for the latter condition?
+                load_imported_component(component.namespaced(root_key))
+              end
+
+              load_local_component(component, &block) unless registered?(key)
+            end
+          end
+
+          self
+        end
+
         private
 
         # @api private
-        def load_local_component(component, default_namespace_fallback = false, &block)
-          if booter.bootable?(component) || component.file_exists?(component_paths)
+        def load_local_component(component, &block)
+          if booter.bootable?(component) || component.file_exists?
             booter.boot_dependency(component) unless finalized?
 
-            require_component(component) do
-              register(component.identifier) { component.instance }
-            end
-          elsif !default_namespace_fallback
-            load_local_component(component.prepend(config.default_namespace), true, &block)
+            register(component.identifier) { component.instance }
           elsif manual_registrar.file_exists?(component)
             manual_registrar.(component)
           elsif block_given?
@@ -698,7 +685,9 @@ module Dry
 
       # Default hooks
       after :configure do
-        add_to_load_path!(*component_paths) if config.add_component_dirs_to_load_path
+        config.component_dirs.each do |dir|
+          add_to_load_path! dir.path if dir.add_to_load_path
+        end
       end
     end
   end

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -32,15 +32,6 @@ module Dry
       end
     end
 
-    # Error raised when a resolved component couldn't be found
-    #
-    # @api public
-    ComponentLoadError = Class.new(StandardError) do
-      def initialize(component)
-        super("could not load component #{component.inspect}")
-      end
-    end
-
     # Error raised when resolved component couldn't be loaded
     #
     # @api public

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -2,6 +2,15 @@
 
 module Dry
   module System
+    # Error raised when a component dir is added to configuration more than once
+    #
+    # @api public
+    ComponentDirAlreadyAddedError = Class.new(StandardError) do
+      def initialize(dir)
+        super("Component directory #{dir.inspect} already added")
+      end
+    end
+
     # Error raised when the container tries to load a component with missing
     # file
     #

--- a/spec/fixtures/lazy_loading/auto_registration_disabled/lib/entities/kitten.rb
+++ b/spec/fixtures/lazy_loading/auto_registration_disabled/lib/entities/kitten.rb
@@ -1,0 +1,7 @@
+# auto_register: false
+# frozen_string_literal: true
+
+module Entities
+  class Kitten
+  end
+end

--- a/spec/fixtures/lazy_loading/auto_registration_disabled/lib/fetch_kitten.rb
+++ b/spec/fixtures/lazy_loading/auto_registration_disabled/lib/fetch_kitten.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class FetchKitten
+end

--- a/spec/fixtures/standard_container_with_default_namespace/lib/test/dep.rb
+++ b/spec/fixtures/standard_container_with_default_namespace/lib/test/dep.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Test
+  class Dep
+  end
+end

--- a/spec/fixtures/standard_container_with_default_namespace/lib/test/example_with_dep.rb
+++ b/spec/fixtures/standard_container_with_default_namespace/lib/test/example_with_dep.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Test
+  class ExampleWithDep
+    include Import["dep"]
+  end
+end

--- a/spec/fixtures/standard_container_without_default_namespace/lib/test/dep.rb
+++ b/spec/fixtures/standard_container_without_default_namespace/lib/test/dep.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Test
+  class Dep
+  end
+end

--- a/spec/fixtures/standard_container_without_default_namespace/lib/test/example_with_dep.rb
+++ b/spec/fixtures/standard_container_without_default_namespace/lib/test/example_with_dep.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Test
+  class ExampleWithDep
+    include Import["test.dep"]
+  end
+end

--- a/spec/fixtures/unit/component/component_dir_1/namespace/nested/component_file.rb
+++ b/spec/fixtures/unit/component/component_dir_1/namespace/nested/component_file.rb
@@ -1,0 +1,1 @@
+# auto_register: false

--- a/spec/integration/container/auto_registration_spec.rb
+++ b/spec/integration/container/auto_registration_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "dry/system/container"
+require "dry/system/loader/autoloading"
+require "zeitwerk"
+
+RSpec.describe "Auto-registration" do
+  specify "Resolving components from a non-finalized container, without a default namespace" do
+    module Test
+      class Container < Dry::System::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join("fixtures/standard_container_without_default_namespace").realpath
+          config.component_dirs.add "lib"
+        end
+      end
+
+      Import = Container.injector
+    end
+
+    example_with_dep = Test::Container["test.example_with_dep"]
+
+    expect(example_with_dep).to be_a Test::ExampleWithDep
+    expect(example_with_dep.dep).to be_a Test::Dep
+  end
+
+  specify "Resolving components from a non-finalized container, with a default namespace" do
+    module Test
+      class Container < Dry::System::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join("fixtures/standard_container_with_default_namespace").realpath
+          config.component_dirs.add "lib" do |dir|
+            dir.default_namespace = "test"
+            # dir.add_to_load_path = false
+          end
+        end
+      end
+
+      Import = Container.injector
+    end
+
+    example_with_dep = Test::Container["example_with_dep"]
+
+    expect(example_with_dep).to be_a Test::ExampleWithDep
+    expect(example_with_dep.dep).to be_a Test::Dep
+  end
+end

--- a/spec/integration/container/autoloading_spec.rb
+++ b/spec/integration/container/autoloading_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe "Autoloading loader" do
     module Test
       class Container < Dry::System::Container
         config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
-        config.add_component_dirs_to_load_path = false
+        config.component_dirs.add "lib" do |dir|
+          dir.add_to_load_path = false
+          dir.default_namespace = "test"
+        end
         config.loader = Dry::System::Loader::Autoloading
-        config.default_namespace = "test"
       end
     end
 

--- a/spec/integration/container/autoloading_spec.rb
+++ b/spec/integration/container/autoloading_spec.rb
@@ -5,7 +5,7 @@ require "dry/system/loader/autoloading"
 require "zeitwerk"
 
 RSpec.describe "Autoloading loader" do
-  specify "Resolves components using Zeitwerk" do
+  specify "Resolving components using Zeitwerk" do
     # See https://github.com/jruby/jruby/issues/5638 for current state
     pending "Zeitwerk is not fully functioning on JRuby" if RUBY_PLATFORM == "java"
 

--- a/spec/integration/container/lazy_loading/auto_registration_disabled_spec.rb
+++ b/spec/integration/container/lazy_loading/auto_registration_disabled_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe "Lazy loading components with auto-registration disabled" do
+  before do
+    module Test
+      class Container < Dry::System::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join("fixtures/lazy_loading/auto_registration_disabled").realpath
+          config.component_dirs.add "lib"
+        end
+      end
+    end
+  end
+
+  it "does not load the component" do
+    expect(Test::Container["fetch_kitten"]).to be
+    expect { Test::Container["entities.kitten"] }.to raise_error(Dry::System::ComponentLoadError)
+  end
+end

--- a/spec/integration/container/lazy_loading/auto_registration_disabled_spec.rb
+++ b/spec/integration/container/lazy_loading/auto_registration_disabled_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe "Lazy loading components with auto-registration disabled" do
     end
   end
 
+  it "reports the component as absent" do
+    expect(Test::Container.key?("entities.kitten")).to be false
+  end
+
   it "does not load the component" do
-    expect(Test::Container["fetch_kitten"]).to be
-    expect { Test::Container["entities.kitten"] }.to raise_error(Dry::System::ComponentLoadError)
+    expect { Test::Container["entities.kitten"] }.to raise_error(Dry::Container::Error)
   end
 end

--- a/spec/integration/container/lazy_loading/bootable_components_spec.rb
+++ b/spec/integration/container/lazy_loading/bootable_components_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe "Lazy loading bootable components" do
         class Container < Dry::System::Container
           configure do |config|
             config.root = SPEC_ROOT.join("fixtures/lazy_loading/shared_root_keys").realpath
+            config.component_dirs.add "lib"
           end
-
-          add_to_load_path! "lib"
         end
       end
     end

--- a/spec/unit/component/locate_spec.rb
+++ b/spec/unit/component/locate_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "dry/system/component"
+require "dry/system/component_dir"
+require "dry/system/config/component_dir"
+require "dry/system/loader"
+
+RSpec.describe Dry::System::Component, ".locate" do
+  subject(:component) { Dry::System::Component.locate(identifier, component_dirs, **options) }
+
+  let(:component_dirs) {
+    component_dir_paths.map { |dir_path|
+      Dry::System::ComponentDir.new(
+        root: root,
+        config: Dry::System::Config::ComponentDir.new(dir_path) { |config|
+          config.default_namespace = "namespace"
+        }
+      )
+    }
+  }
+  let(:component_dir_paths) { %w[component_dir_1 component_dir_2] }
+  let(:root) { SPEC_ROOT.join("fixtures/unit/component") }
+  let(:options) { {} }
+
+  context "component file located" do
+    let(:identifier) { "nested.component_file" }
+
+    it "returns a component" do
+      expect(component).to be_a Dry::System::Component
+    end
+
+    it "has a file" do
+      expect(component.file_exists?).to be true
+    end
+
+    it "matches the first component file found within the given component dirs" do
+      expect(component.file_path.to_s).to eq root.join("component_dir_1/namespace/nested/component_file.rb").to_s
+    end
+
+    context "component dir paths given in another order" do
+      let(:component_dir_paths) { %w[component_dir_2 component_dir_1] }
+
+      it "matches the first component file found within the dirs in the given order" do
+        expect(component.file_path.to_s).to eq root.join("component_dir_2/namespace/nested/component_file.rb").to_s
+      end
+    end
+
+    it "loads the component dir's namespace" do
+      expect(component.namespace).to eq "namespace"
+    end
+
+    it "loads any options specified within the file's magic comments" do
+      expect(component.options).to include(auto_register: false)
+    end
+  end
+
+  context "component file not located" do
+    let(:identifier) { "nested.missing" }
+
+    it "returns a component" do
+      expect(component).to be_a Dry::System::Component
+    end
+
+    it "does not have a file" do
+      expect(component.file_exists?).to be false
+    end
+
+    it "does not have a file_path" do
+      expect(component.file_path).to be nil
+    end
+
+    it "does not have a namespace" do
+      expect(component.namespace).to be nil
+    end
+
+    it "does not have additional file-provided options" do
+      expect(component.options).not_to include :auto_register
+    end
+  end
+end

--- a/spec/unit/component_dir_spec.rb
+++ b/spec/unit/component_dir_spec.rb
@@ -1,0 +1,46 @@
+require "dry/system/component_dir"
+require "dry/system/config/component_dir"
+
+RSpec.describe Dry::System::ComponentDir do
+  subject(:component_dir) { described_class.new(config: config, root: root) }
+  let(:config) { Dry::System::Config::ComponentDir.new(dir_path) }
+  let(:dir_path) { "component_dir" }
+  let(:root) { SPEC_ROOT.join("fixtures/unit").realpath }
+
+  describe "config" do
+    it "delegates config methods to the config" do
+      expect(component_dir.path).to eql config.path
+      expect(component_dir.auto_register).to eql config.auto_register
+      expect(component_dir.add_to_load_path).to eql config.add_to_load_path
+      expect(component_dir.default_namespace).to eql config.default_namespace
+    end
+  end
+
+  describe "#full_path" do
+    it "is a pathname" do
+      expect(component_dir.root).to be_a_kind_of Pathname
+    end
+
+    it "returns the config's path appended onto the root" do
+      expect(component_dir.full_path.to_s).to eq "#{root}/#{dir_path}"
+    end
+  end
+
+  describe "#component_file" do
+    context "component file exists matching the given path" do
+      it "returns the full path to the file" do
+        expect(component_dir.component_file("component_file").to_s).to eq "#{root}/#{dir_path}/component_file.rb"
+      end
+
+      it "returns a pathname" do
+        expect(component_dir.component_file("component_file")).to be_a_kind_of Pathname
+      end
+    end
+
+    context "component file matching the given path does not exist" do
+      it "returns nil" do
+        expect(component_dir.component_file("missing")).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -3,26 +3,11 @@
 require "dry/system/component"
 require "dry/system/loader"
 
-RSpec.describe Dry::System::Component, clear_cache: true do
+RSpec.describe Dry::System::Component do
   subject(:component) { Dry::System::Component.new(name, loader: loader_class) }
   let(:loader_class) { Dry::System::Loader }
 
-  before clear_cache: true do
-    # Skip the internal cache for most of examples below, to allow for for a fresh
-    # component to be used in each. This is important for tests that rely on adjusting the
-    # component's dependencies, like the loader.
-    described_class.instance_variable_set :@cache, nil
-  end
-
-  describe ".new", clear_cache: false do
-    it "caches components" do
-      create = lambda {
-        Dry::System::Component.new("foo.bar", namespace: "foo")
-      }
-
-      expect(create.()).to be(create.())
-    end
-
+  describe ".new" do
     it "allows to have the same key multiple times in the identifier/path" do
       component = Dry::System::Component.new("foo.bar.foo", namespace: "foo")
       expect(component.identifier).to eql("bar.foo")
@@ -65,19 +50,6 @@ RSpec.describe Dry::System::Component, clear_cache: true do
       end
     end
 
-    describe "#require!" do
-      let(:loader) { instance_spy(Dry::System::Loader) }
-
-      before do
-        allow(loader_class).to receive(:new).with("foo", anything) { loader }
-      end
-
-      it "requires the component via the loader" do
-        component.require!
-        expect(loader).to have_received(:require!)
-      end
-    end
-
     describe "#instance" do
       it "builds an instance" do
         class Foo; end
@@ -94,12 +66,6 @@ RSpec.describe Dry::System::Component, clear_cache: true do
       end
     end
 
-    describe "#file" do
-      it "returns relative path to the component file" do
-        expect(component.file).to eql("test/foo.rb")
-      end
-    end
-
     describe "#namespace" do
       it "returns configured namespace" do
         expect(component.namespace).to be(nil)
@@ -112,7 +78,6 @@ RSpec.describe Dry::System::Component, clear_cache: true do
 
         expect(namespaced.identifier).to eql("foo")
         expect(namespaced.path).to eql("test/foo")
-        expect(namespaced.file).to eql("test/foo.rb")
       end
     end
 

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -1,0 +1,43 @@
+require "dry/system/config/component_dirs"
+require "dry/system/config/component_dir"
+
+RSpec.describe Dry::System::Config::ComponentDirs do
+  subject(:component_dirs) { described_class.new }
+
+  describe "#add" do
+    context "adding and configuring a component dir" do
+      it "adds the component dir based on the provided configuration" do
+        expect {
+          component_dirs.add "test/path" do |dir|
+            dir.auto_register = false
+            dir.add_to_load_path = false
+          end
+        }
+          .to change { component_dirs.dirs.keys.length }
+          .from(0).to(1)
+
+        dir = component_dirs.dirs["test/path"]
+
+        expect(dir.path).to eq "test/path"
+        expect(dir.auto_register).to eq false
+        expect(dir.add_to_load_path).to eq false
+      end
+    end
+
+    context "adding an already-configured component dir" do
+      it "adds the component dir" do
+        component_dir = Dry::System::Config::ComponentDir.new("test/path") do |dir|
+          dir.auto_register = false
+          dir.add_to_load_path = false
+        end
+
+        expect { component_dirs.add component_dir }
+          .to change { component_dirs.dirs.keys.length }
+          .from(0)
+          .to(1)
+
+        expect(component_dirs.dirs["test/path"]).to eql component_dir
+      end
+    end
+  end
+end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -13,11 +13,8 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
-          config.component_dirs = ["components"]
+          config.component_dirs.add "components"
         end
-
-        add_to_load_path!("components")
-        auto_register!("components")
       end
     end
 
@@ -35,10 +32,8 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
-          config.component_dirs = ["components"]
+          config.component_dirs.add "components"
         end
-
-        add_to_load_path!("components")
       end
     end
 
@@ -63,10 +58,8 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       Class.new(Dry::System::Container) do
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
-          config.component_dirs = ["components"]
+          config.component_dirs.add "components"
         end
-
-        add_to_load_path!("components")
       end
     end
 
@@ -108,12 +101,10 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
-          config.component_dirs = ["namespaced_components"]
-          config.default_namespace = "namespaced"
+          config.component_dirs.add "namespaced_components" do |dir|
+            dir.default_namespace = "namespaced"
+          end
         end
-
-        add_to_load_path!("namespaced_components")
-        auto_register!("namespaced_components")
       end
     end
 
@@ -127,12 +118,11 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
-          config.component_dirs = ["components"]
-          config.default_namespace = "namespace"
-        end
 
-        add_to_load_path!("components")
-        auto_register!("components")
+          config.component_dirs.add "components" do |dir|
+            # dir.default_namespace = "namespace"
+          end
+        end
       end
     end
 
@@ -146,12 +136,10 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
-          config.component_dirs = ["multiple_namespaced_components"]
-          config.default_namespace = "multiple.level"
+          config.component_dirs.add "multiple_namespaced_components" do |dir|
+            dir.default_namespace = "multiple.level"
+          end
         end
-
-        add_to_load_path!("multiple_namespaced_components")
-        auto_register!("multiple_namespaced_components")
       end
     end
 
@@ -163,6 +151,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
     before do
       class Test::Loader < Dry::System::Loader
         def call(*args)
+          require!
           constant.respond_to?(:call) ? constant : constant.new(*args)
         end
       end
@@ -170,12 +159,9 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
-          config.component_dirs = ["components"]
+          config.component_dirs.add "components"
           config.loader = ::Test::Loader
         end
-
-        add_to_load_path!("components")
-        auto_register!("components")
       end
     end
 
@@ -191,8 +177,8 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
         class Test::Container < Dry::System::Container
           configure do |config|
             config.root = SPEC_ROOT.join("fixtures").realpath
-            config.component_dirs = ["components"]
-            config.auto_register = %w[unknown_dir]
+            config.component_dirs.add "components"
+            config.component_dirs.add "unknown_dir"
           end
         end
       end

--- a/spec/unit/container/hooks/load_path_hook_spec.rb
+++ b/spec/unit/container/hooks/load_path_hook_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Dry::System::Container, "Default hooks / Load path" do
   let(:container) {
     Class.new(Dry::System::Container) {
       config.root = SPEC_ROOT.join("fixtures/test")
-      config.component_dirs = ["lib"]
     }
   }
 
@@ -16,9 +15,11 @@ RSpec.describe Dry::System::Container, "Default hooks / Load path" do
     $LOAD_PATH.replace(@load_path_before)
   end
 
-  context "add_component_dirs_to_load_path is true" do
+  context "component_dirs configured with add_to_load_path = true" do
     before do
-      container.config.add_component_dirs_to_load_path = true
+      container.config.component_dirs.add "lib" do |dir|
+        dir.add_to_load_path = true
+      end
     end
 
     it "adds the component dirs to the load path" do
@@ -28,9 +29,11 @@ RSpec.describe Dry::System::Container, "Default hooks / Load path" do
     end
   end
 
-  context "add_component_dirs_to_load_path is true" do
+  context "component_dirs configured with add_to_load_path = false" do
     before do
-      container.config.add_component_dirs_to_load_path = false
+      container.config.component_dirs.add "lib" do |dir|
+        dir.add_to_load_path = false
+      end
     end
 
     it "does not change the load path" do

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -26,17 +26,15 @@ RSpec.describe Dry::System::Container, ".import" do
       class Test::Other < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures/import_test").realpath
+          config.component_dirs.add "lib"
         end
-
-        add_to_load_path!("lib")
       end
 
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures/test").realpath
+          config.component_dirs.add "lib"
         end
-
-        add_to_load_path!("lib")
 
         import other: Test::Other
       end

--- a/spec/unit/container/load_path_spec.rb
+++ b/spec/unit/container/load_path_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dry::System::Container, "Load path handling" do
   let(:container) {
     class Test::Container < Dry::System::Container
       config.root = SPEC_ROOT.join("fixtures/test")
-      config.component_dirs = ["lib"]
+      config.component_dirs.add "lib"
     end
 
     Test::Container

--- a/spec/unit/loader/autoloading_spec.rb
+++ b/spec/unit/loader/autoloading_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require "dry/system/loader/autoloading"
+require "dry/system/component"
 
 RSpec.describe Dry::System::Loader::Autoloading do
   describe "#require!" do
-    subject(:loader) { described_class.new("test/not_loaded_const") }
+    subject(:loader) { described_class.new(component) }
+    let(:component) { Dry::System::Component.new("test.not_loaded_const") }
 
     before do
       allow(loader).to receive(:require)

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -3,18 +3,32 @@
 require "dry/inflector"
 require "dry/system/loader"
 require "singleton"
+require "dry/system/component"
 
 RSpec.describe Dry::System::Loader do
+  subject(:loader) { described_class.new(component) }
+
   describe "#require!" do
-    subject(:loader) { Dry::System::Loader.new("test/bar") }
+    let(:component) { Dry::System::Component.new("test.bar") }
 
     before do
       allow(loader).to receive(:require)
     end
 
-    it "requires the loader's path" do
-      loader.require!
-      expect(loader).to have_received(:require).with "test/bar"
+    context "component file exists" do
+      let(:component) { Dry::System::Component.new("test.bar", file_path: "path/to/test/bar.rb") }
+
+      it "requires the components's path" do
+        loader.require!
+        expect(loader).to have_received(:require).with "test/bar"
+      end
+    end
+
+    context "component file does not exist" do
+      it "does not require the components's path" do
+        loader.require!
+        expect(loader).not_to have_received(:require)
+      end
     end
 
     it "returns self" do
@@ -43,7 +57,7 @@ RSpec.describe Dry::System::Loader do
     end
 
     context "with a singular name" do
-      subject(:loader) { Dry::System::Loader.new("test/bar") }
+      let(:component) { Dry::System::Component.new("test.bar") }
 
       let(:constant) { Test::Bar }
 
@@ -55,7 +69,7 @@ RSpec.describe Dry::System::Loader do
     end
 
     context "with a plural name" do
-      subject(:loader) { Dry::System::Loader.new("test/bars") }
+      let(:component) { Dry::System::Component.new("test.bars") }
 
       let(:constant) { Test::Bars }
 
@@ -67,7 +81,7 @@ RSpec.describe Dry::System::Loader do
     end
 
     context "with a constructor accepting args" do
-      subject(:loader) { Dry::System::Loader.new("test/bar") }
+      let(:component) { Dry::System::Component.new("test.bar") }
 
       before do
         module Test
@@ -84,9 +98,12 @@ RSpec.describe Dry::System::Loader do
     end
 
     context "with a custom inflector" do
-      let(:inflector) { Dry::Inflector.new { |i| i.acronym("API") } }
-
-      subject(:loader) { Dry::System::Loader.new("test/api_bar", inflector) }
+      let(:component) {
+        Dry::System::Component.new(
+          "test.api_bar",
+          inflector: Dry::Inflector.new { |i| i.acronym("API") }
+        )
+      }
 
       let(:constant) { Test::APIBar }
 


### PR DESCRIPTION
This adds a "rich" `component_dirs` setting, which allows multiple component directories to be added and configured independently. For example:

```ruby
class MyApp::Container < Dry::System::Container
  configure do |config|
    config.root = __dir__

    config.component_dirs.add "lib" do |dir|
      dir.auto_register = true    # defaults to true
      dir.add_to_load_path = true # defaults to true
      dir.default_namespace = "my_app"
    end
    
    config.component_dirs.add "another" do |dir|
      # etc.
    end
  end
end
```

The following top-level settings have been removed:

- `default_namespace`
- `add_component_dirs_to_load_path`
- `auto_register`

Since these are now configurable per-component directory, they no longer make sense at the top-level (and really, they only mostly worked by happenstance until now, relying upon the fact that most usages of dry-system involved a single primary directory for auto-registration).

The `component_dirs` setting value is a custom object, a `Dry::System::Config::ComponentDirs`, which yields a `Dry::System::Config::ComponentDir` for each added directory. These are simple classes including `Dry::Configurable` and delegating all methods to the internal `config` object via `#method_missing` (sidenote: I've followed this pattern in so many places now I think dry-configurable should support it out of the box). The `ComponentDirs` setting value is made cloneable (which is required so that we don't needlessly propagate component dir configs across different containers) via a new `cloneable` option on dry-configurable settings (see https://github.com/dry-rb/dry-configurable/pull/102, which I'll release after some final testing of this branch of dry-system).

The `component_dirs` are then exposed as `Container.component_dirs`, which are instances of `Dry::System::ComponentDir`, representing the component directory placed within the container's configured `root`. These objects wrap the component dir's config, and importantly, provide a `#component_file(component_path)` method for finding component files (i.e. Ruby source files) within the directory.

This method is then used by another new method, `Component.locate(identifier, component_dirs, **options)`, called from `Container.component`, which is the sole method for the container to build `Component` instances. `.locate` is passed the container's array of `component_dis`, and will return a `Component` instance for the first matching component file (in this way, component dirs act like a typical "path", in that the first match wins).

The benefit of this arrangement is that because `Component.locate` now has the full set of `ComponentDir` objects, which contain all their configuration, then the resulting `Component` instance can access that configuration as required! In particular, this means a component found within a `component_dir` configured with a `default_namespace` can be initialized with that namespace. This allows us to greatly simplify `Container.load_local_component` (more on that later) and reduce it from a two-pass operation (in which the method would call itself again with the `default_namespace` prepended if a component could not be found in the first pass) to a single-pass.

With this change, components are found directly from the file system in _both_ main container use cases, (a) when finalizing the container and auto-registering all components, as well as (b) when components are lazily loaded in a non-finalized container. This allows us to provide a `file_path` arg when initializing a `Component`, which means every component can now be asked if its `#file_exists?`. This new consistency across components allows us to further simplify `.load_local_component` by doing away with the entire `.require_component` block method, whose only jobs were to (a) try and find a file matching the already-initialized component (no longer required, we know about the file up front now!), and (b) require that file (also no longer required, since this PR has `Loader#call` make a call to `require!` as a first step, keeping in mind that `require!` may be a no-op for the autoloading loader). This change reduces the amount of low-level implementation detail that `Container` needs to know about, and pushes that detail down into the place where it is most relevant, the `Loader`.

(A small supporting change to `Loader` is that it's now initialized with the whole `component`, rather than just the component's path. This allows it to check if the `component.file_exists?` before attempting to require it)

Another way we increase the consistency across lazily-loaded vs auto-registered components is by adding a check for a file's magic comment-based configuration as a step inside `Component.locate`. This means that if a component has a magic comment specifying `auto_register: false`, then it can also be skipped when lazily resolving, which was never the case before! I plan to take this further and completely remove the magic comment parsing from `AutoRegistrar`, but that will happen when I remove `Container.auto_register!` in a follow-up PR (this current PR is already big enough!).

A big upshot of all these changes is that they allow `Container.load_component` and `.load_local_component` to be dramatically simplified! `.load_component` now contains _all_ the detail of deciding which loading mechanism to use. Instead of 4 levels of nesting, it now has only 1 level, with two early returns for the cases where a bootable component has already done the work of loading the specified component. `.load_local_component` drops from a 14-line method with multiple conditionals (and lots of overlap with `.load_component`) to a 3-line method with the simple job of registering the component or not. This pair of methods has confused me nearly every time I've encountered them over the last few years, and I'm so happy the changes for the `component_dirs` made this refactoring possible!

This PR has **BREAKING CHANGES**:

- The removal of the `default_namespace`, `add_component_dirs_to_load_path`, `auto_register` top-level settings from `Dry::System::Container`
- The removal of `Dry::System::ComponentLoadError`, which was previously only raised in a very particular circumstance, when attempting to lazily load a local component, but failing to find its file. Now we let a `Dry::Container::Error` bubble up like all other cases of attempting to resolve a component that doesn't exist. The custom exception didn't reveal anything useful in its error message, and it's better to be consistent here, I think.

As for next steps here:

- I'd love your review of this PR. It's an important change, so please take the time you need.
- I'll test these changes with one of the larger dry-system-backed production apps I have access to
- If that goes well, I'll release the dry-configurable changes in https://github.com/dry-rb/dry-configurable/pull/102 and update this branch to used the released version
- Once all reviewers are happy, we can merge this PR

There's one follow-up change I'd like to make before this can be released in a new gem version, and that's to rip out `Container.auto_register!` given all auto-registration should now happen only over the configured `component_dirs`. This requires some changes to dry-rails, so I'd like to do that as a separate PR.