### PR TITLE
Update docsite for component dirs

### DIFF
--- a/docsite/source/auto-import.html.md
+++ b/docsite/source/auto-import.html.md
@@ -57,10 +57,8 @@ class Application < Dry::System::Container
   configure do |config|
     config.name = :app
     config.root = Pathname('/my/app')
-    config.auto_register = %w(lib)
+    config.component_dirs.add 'lib'
   end
-
-  load_paths!('lib')
 end
 
 # system/import.rb

--- a/docsite/source/booting.html.md
+++ b/docsite/source/booting.html.md
@@ -6,7 +6,7 @@ name: dry-system
 
 In some cases a dependency can be huge, so huge it needs to load some additional files (often 3rd party code) and it may rely on custom configuration.
 
-Because of this reason `dry-system` has the concept of booting a dependency.
+Because of this reason dry-system has the concept of booting a dependency.
 
 The convention is pretty simple. You put files under `system/boot` directory and use your container to register dependencies with the ability to postpone finalization. This gives us a way to define what's needed but load it and boot it on demand.
 
@@ -44,7 +44,7 @@ Application['database']
 
 ### Lifecycles
 
-In some cases, a bootable dependency may have multiple stages of initialization, to support it `dry-system` provides 3 levels of booting:
+In some cases, a bootable dependency may have multiple stages of initialization, to support it dry-system provides 3 levels of booting:
 
 * `init` - basic setup code, here you can require 3rd party code and perform basic configuration
 * `start` - code that needs to run for a component to be usable at application's runtime
@@ -83,7 +83,7 @@ Application.boot(:logger) do
   init do
     require 'logger'
   end
-  
+
   start do
     register(:logger, Logger.new($stdout))
   end

--- a/docsite/source/container.html.md
+++ b/docsite/source/container.html.md
@@ -38,13 +38,10 @@ class Application < Dry::System::Container
   configure do |config|
     config.root = Pathname('./my/app')
 
-    # we set 'lib' relative to `root` as a path which contains class definitions
+    # Add a 'lib' component dir (relative to `root`), containing class definitions
     # that can be auto-registered
-    config.auto_register = 'lib'
+    config.component_dirs.add 'lib'
   end
-
-  # this alters $LOAD_PATH hence the `!`
-  load_paths!('lib')
 end
 
 # under /my/app/lib/logger.rb we put

--- a/docsite/source/container.html.md
+++ b/docsite/source/container.html.md
@@ -4,7 +4,7 @@ layout: gem-single
 name: dry-system
 ---
 
-Main API of `dry-system` is the abstract container that you inherit from. It allows you to configure basic settings and exposes APIs for requiring files easily. Container is the entry point to your application, and it encapsulates application's state.
+The main API of dry-system is the abstract container that you inherit from. It allows you to configure basic settings and exposes APIs for requiring files easily. Container is the entry point to your application, and it encapsulates application's state.
 
 Let's say you want to define an application container that will provide a logger:
 

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -37,11 +37,11 @@ This comes with a bunch of nice benefits:
 * It makes it possible to load components in complete isolation. In example you can run a single test for a single component and only required files will be loaded, or you can run a rake task and it will only load the things it needs.
 * It opens up doors to better instrumentation and debugging tools
 
-You can use `dry-system` in a new application or add it to an existing application. It should Just Work™ but if it doesn't please [report an issue](https://github.com/dry-rb/dry-system/issues).
+You can use dry-system in a new application or add it to an existing application. It should Just Work™ but if it doesn't please [report an issue](https://github.com/dry-rb/dry-system/issues).
 
 ### Example
 
-This library is the backbone of [dry-web](https://github.com/dry-rb/dry-web), if you'd like to see a full-blown application example check out [Berg](https://github.com/icelab/berg). Please notice that `dry-system` is framework agnostic, in fact, it could be treated as a toolkit for building frameworks, as it provides facilities that are typically needed by frameworks.
+This library is the backbone of [dry-web](https://github.com/dry-rb/dry-web), if you'd like to see a full-blown application example check out [Berg](https://github.com/icelab/berg). Please notice that dry-system is framework agnostic, in fact, it could be treated as a toolkit for building frameworks, as it provides facilities that are typically needed by frameworks.
 
 ### Rails support
 
@@ -49,6 +49,6 @@ If you want to use dry-system with Rails, it's recommended to use [dry-rails](/g
 
 ### Credits
 
-* `dry-system` has been extracted from an experimental project called Rodakase created by [solnic](https://github.com/solnic). Later on Rodakase was renamed to [dry-web](https://github.com/dry-rb/dry-web).
+* dry-system has been extracted from an experimental project called Rodakase created by [solnic](https://github.com/solnic). Later on Rodakase was renamed to [dry-web](https://github.com/dry-rb/dry-web).
 * System/Component and lifecycle triggers are inspired by Clojure's [component](https://github.com/stuartsierra/component) library by [Stuart Sierra](https://github.com/stuartsierra)
 


### PR DESCRIPTION
This is just a minimal set of changes to make sure the code in the docs reflects the new `component_dirs` setting (and related changes).

I also removed the code-formatting of "dry-system" throughout the docs (since it's the name of our gem, and not a code element).