### PR TITLE
Add changelog entry for 0.19.0

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,6 +1,6 @@
 ---
 - version: 0.19.0
-  date: 2021-03-04
+  date: 2021-04-20
   summary:
   added:
   - |-
@@ -13,15 +13,18 @@
         configure do |config|
           config.root = __dir__
 
+          # Defaults for all component dirs can be configured separately
+          config.component_dirs.auto_register = true # default is already true
+
+          # Component dirs can be added and configured independently
           config.component_dirs.add "lib" do |dir|
-            dir.auto_register = true    # defaults to true
             dir.add_to_load_path = true # defaults to true
             dir.default_namespace = "my_app"
           end
 
-          config.component_dirs.add "custom_components" do |dir|
-            # etc.
-          end
+          # All component dir settings are optional. Component dirs relying on default
+          # settings can be added like so:
+          config.component_dirs.add "custom_components"
         end
       end
       ```
@@ -34,23 +37,51 @@
       - `loader`, a custom replacement for the default `Dry::System::Loader` to be used for the component dir
       - `memoize`, a boolean, to enable/disable memoizing all components in the directory, or a proc accepting a `Dry::System::Component` instance and returning a truthy or falsey value. Providing a proc allows a memoization policy to apply on a per-component basis
 
-      All component dir settings are optional.
+      **All component dir settings are optional.**
 
-      (@timriley in #155 and #157)
+      (@timriley in #155, #157, and #162)
   - |-
-    A new autoloading-friendly `Dry::System::Loader::Autoloading` is available, which is tested and works with [Zeitwerk](https://github.com/fxn/zeitwerk)
+    A new autoloading-friendly `Dry::System::Loader::Autoloading` is available, which is tested to work with [Zeitwerk](https://github.com/fxn/zeitwerk) 🎉
 
-    Configure this on the container (either via the container's top-level `loader` setting or as the `loader` for any `component_dirs`), and the loader will no longer `require` any components, instead allowing missing constant resolution to trigger the loading of the required file.
+      Configure this on the container (via a component dir `loader` setting), and the loader will no longer `require` any components, instead allowing missing constant resolution to trigger the loading of the required file.
 
-    This loader presumes an autoloading system like Zeitwerk has already been enabled and appropriately configured. (@timriley in #153)
+      This loader presumes an autoloading system like Zeitwerk has already been enabled and appropriately configured.
+
+      A recommended setup is as follows:
+
+      ```ruby
+      require "dry/system/container"
+      require "dry/system/loader/autoloading"
+      require "zeitwerk"
+
+      class MyApp::Container < Dry::System::Container
+        configure do |config|
+          config.root = __dir__
+
+          config.component_dirs.loader = Dry::System::Loader::Autoloading
+          config.component_dirs.add_to_load_path = false
+
+          config.component_dirs.add "lib" do |dir|
+            # ...
+          end
+        end
+      end
+
+      loader = Zeitwerk::Loader.new
+      loader.push_dir MyApp::Container.config.root.join("lib").realpath
+      loader.setup
+      ```
+
+    (@timriley in #153)
   - |-
     [BREAKING] `Dry::System::Component` instances (which users of dry-system will interact with via custom loaders, as well as via the `auto_register` and `memoize` component dir settings described above) now return a `Dry::System::Identifier` from their `#identifier` method. The raw identifier string may be accessed via the identifier's own `#key` or `#to_s` methods. `Identifier` also provides a helpful namespace-aware `#start_with?` method for returning whether the identifier begins with the provided namespace(s) (@timriley in #158)
   changed:
   - "Components with `# auto_register: false` magic comments in their source files are now properly ignored when lazy loading (@timriley in #155)"
   - "`# memoize: true` and `# memoize: false` magic comments at top of component files are now respected (@timriley in #155)"
-  - "[BREAKING] `Dry::System::Container.load_paths!` has been renamed to `.add_to_load_path!`. This method now exists as a mere convenience only. Calling this method is no longer required for any configured `component_dirs`; these are now added to the load path automatically (@timriley in #153 and #155)
+  - "[BREAKING] `Dry::System::Container.load_paths!` has been renamed to `.add_to_load_path!`. This method now exists as a mere convenience only. Calling this method is no longer required for any configured `component_dirs`; these are now added to the load path automatically (@timriley in #153 and #155)"
   - "[BREAKING] `auto_register` container setting has been removed. Configured directories to be auto-registered by adding `component_dirs` instead (@timriley in #155)"
   - "[BREAKING] `default_namespace` container setting has been removed. Set it when adding `component_dirs` instead (@timriley in #155)"
+  - "[BREAKING] `loader` container setting has been nested under `component_dirs`, now available as `component_dirs.loader` to configure a default loader for all component dirs, as well as on individual component dirs when being added (@timriley in #162)"
   - "[BREAKING] `Dry::System::ComponentLoadError` is no longer raised when a component could not be lazy loaded; this was only raised in a single specific failure condition. Instead, a `Dry::Container::Error` is raised in all cases of components failing to load (@timriley in #155)"
   - "[BREAKING] `Dry::System::Container.auto_register!` has been removed. Configure `component_dirs` instead. (@timriley in #157)"
   - "[BREAKING] The `Dry::System::Loader` interface has changed. It is now a static interface, no longer initialized with a component. The component is instead passed to each method as an argument: `.require!(component)`, `.call(component, *args)`, `.constant(component)` (@timriley in #157)"

--- a/changelog.yml
+++ b/changelog.yml
@@ -1,4 +1,60 @@
 ---
+- version: 0.19.0
+  date: 2021-03-04
+  summary:
+  added:
+  - |-
+    New `component_dirs` setting on `Dry::System::Container`, which must be used for specifying the directories which dry-system will search for component source files.
+
+      Each added component dir is relative to the container's `root`, and can have its own set of settings configured:
+
+      ```ruby
+      class MyApp::Container < Dry::System::Container
+        configure do |config|
+          config.root = __dir__
+
+          config.component_dirs.add "lib" do |dir|
+            dir.auto_register = true    # defaults to true
+            dir.add_to_load_path = true # defaults to true
+            dir.default_namespace = "my_app"
+          end
+
+          config.component_dirs.add "custom_components" do |dir|
+            # etc.
+          end
+        end
+      end
+      ```
+
+      The following settings are available for configuring added `component_dirs`:
+
+      - `auto_register`, a boolean, or a proc accepting a `Dry::System::Component` instance and returning a truthy or falsey value. Providing a proc allows an auto-registration policy to apply on a per-component basis
+      - `add_to_load_path`, a boolean
+      - `default_namespace`, a string representing the leading namespace segments to be stripped from the component's identifier (given the identifier is derived from the component's fully qualified class name)
+      - `loader`, a custom replacement for the default `Dry::System::Loader` to be used for the component dir
+      - `memoize`, a boolean, to enable/disable memoizing all components in the directory, or a proc accepting a `Dry::System::Component` instance and returning a truthy or falsey value. Providing a proc allows a memoization policy to apply on a per-component basis
+
+      All component dir settings are optional.
+
+      (@timriley in #155 and #157)
+  - |-
+    A new autoloading-friendly `Dry::System::Loader::Autoloading` is available, which is tested and works with [Zeitwerk](https://github.com/fxn/zeitwerk)
+
+    Configure this on the container (either via the container's top-level `loader` setting or as the `loader` for any `component_dirs`), and the loader will no longer `require` any components, instead allowing missing constant resolution to trigger the loading of the required file.
+
+    This loader presumes an autoloading system like Zeitwerk has already been enabled and appropriately configured. (@timriley in #153)
+  - |-
+    [BREAKING] `Dry::System::Component` instances (which users of dry-system will interact with via custom loaders, as well as via the `auto_register` and `memoize` component dir settings described above) now return a `Dry::System::Identifier` from their `#identifier` method. The raw identifier string may be accessed via the identifier's own `#key` or `#to_s` methods. `Identifier` also provides a helpful namespace-aware `#start_with?` method for returning whether the identifier begins with the provided namespace(s) (@timriley in #158)
+  changed:
+  - "Components with `# auto_register: false` magic comments in their source files are now properly ignored when lazy loading (@timriley in #155)"
+  - "`# memoize: true` and `# memoize: false` magic comments at top of component files are now respected (@timriley in #155)"
+  - "[BREAKING] `Dry::System::Container.load_paths!` has been renamed to `.add_to_load_path!`. This method now exists as a mere convenience only. Calling this method is no longer required for any configured `component_dirs`; these are now added to the load path automatically (@timriley in #153 and #155)
+  - "[BREAKING] `auto_register` container setting has been removed. Configured directories to be auto-registered by adding `component_dirs` instead (@timriley in #155)"
+  - "[BREAKING] `default_namespace` container setting has been removed. Set it when adding `component_dirs` instead (@timriley in #155)"
+  - "[BREAKING] `Dry::System::ComponentLoadError` is no longer raised when a component could not be lazy loaded; this was only raised in a single specific failure condition. Instead, a `Dry::Container::Error` is raised in all cases of components failing to load (@timriley in #155)"
+  - "[BREAKING] `Dry::System::Container.auto_register!` has been removed. Configure `component_dirs` instead. (@timriley in #157)"
+  - "[BREAKING] The `Dry::System::Loader` interface has changed. It is now a static interface, no longer initialized with a component. The component is instead passed to each method as an argument: `.require!(component)`, `.call(component, *args)`, `.constant(component)` (@timriley in #157)"
+  - "[BREAKING] `Dry::System::Container.require_path` has been removed. Provide custom require behavior by configuring your own `loader` (@timriley in #153)"
 - version: 0.18.1
   summary:
   date: '2020-08-26'
@@ -19,24 +75,24 @@
       When searching for bootable files, the first match will win, and any subsequent same-named files will not be loaded. In this way, the `bootable_dirs` act similarly to the `$PATH` in a shell environment.
   changed:
 - version: 0.17.0
-  summary: 
+  summary:
   date: '2020-02-19'
   fixed:
   - 'Works with the latest dry-configurable version (issue #141) (@solnic)'
-  added: 
+  added:
   changed:
   - Depends on dry-configurable `=> 0.11.1` now (@solnic)
 - version: 0.16.0
-  summary: 
+  summary:
   date: '2020-02-15'
   changed:
   - Plugins can now define their own settings which are available in the `before(:configure)`
     hook (@solnic)
   - Dependency on dry-configurable was bumped to `~> 0.11` (@solnic)
 - version: 0.15.0
-  summary: 
+  summary:
   date: '2020-01-30'
-  fixed: 
+  fixed:
   added: |
     New hook - `before(:configure)` which a plugin should use if it needs to declare new settings (@solnic)
 
@@ -50,10 +106,10 @@
   - Centralize error definitions in `lib/dry/system/errors.rb` (@cgeorgii)
   - All built-in plugins use `before(:configure)` now to declare their settings (@solnic)
 - version: 0.14.1
-  summary: 
+  summary:
   date: '2020-01-22'
-  fixed: 
-  added: 
+  fixed:
+  added:
   changed:
   - Use `Kernel.require` explicitly to avoid issues with monkey-patched `require`
     from ActiveSupport (@solnic)


### PR DESCRIPTION
I'd like to release 0.19.0 later this week. The CHANGELOG entry is so massive I thought it would be worth running past you all as a check :)