### PR TITLE
Allow custom system-wide defaults to be configured for all component dirs

### DIFF
--- a/lib/dry/system/component_dir.rb
+++ b/lib/dry/system/component_dir.rb
@@ -86,21 +86,12 @@ module Dry
         container.root.join(path)
       end
 
-      # Returns the explicitly configured loader for the component dir, otherwise the
-      # default loader configured for the container
-      #
-      # @see Dry::System::Loader
-      # @api private
-      def loader
-        config.loader || container.config.loader
-      end
-
       # @api private
       def component_options
         {
           auto_register: auto_register,
           loader: loader,
-          memoize: memoize,
+          memoize: memoize
         }
       end
 

--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -1,4 +1,5 @@
 require "dry/configurable"
+require "dry/system/loader"
 
 module Dry
   module System
@@ -9,7 +10,7 @@ module Dry
         setting :auto_register, true
         setting :add_to_load_path, true
         setting :default_namespace
-        setting :loader
+        setting :loader, Dry::System::Loader
         setting :memoize, false
 
         attr_reader :path

--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -7,20 +7,167 @@ module Dry
       class ComponentDir
         include Dry::Configurable
 
+        # @!group Settings
+
+        # @!method auto_register=(policy)
+        #
+        #   Sets the auto-registration policy for the component dir.
+        #
+        #   This may be a simple boolean to enable or disable auto-registration for all
+        #   components, or a proc accepting a `Dry::Sytem::Component` and returning a
+        #   boolean to configure auto-registration on a per-component basis
+        #
+        #   Defaults to `true`.
+        #
+        #   @param policy [Boolean, Proc]
+        #   @return [Boolean, Proc]
+        #
+        #   @example
+        #     dir.auto_register = false
+        #
+        #   @example
+        #     dir.auto_register = proc do |component|
+        #       !component.start_with?("entities")
+        #     end
+        #
+        #   @see auto_register
+        #   @see Component
+        #
+        # @!method auto_register
+        #
+        #   Returns the configured auto-registration policy.
+        #
+        #   @return [Boolean, Proc] the configured policy
+        #
+        #   @see auto_register=
         setting :auto_register, true
+
+        # @!method add_to_load_path=(policy)
+        #
+        #   Sets whether the dir should be added to the `$LOAD_PATH` after the container
+        #   is configured.
+        #
+        #   Defaults to `true`. This may need to be set to `false` when using a class
+        #   autoloading system.
+        #
+        #   @param policy [Boolean]
+        #   @return [Boolean]
+        #
+        #   @see add_to_load_path
+        #   @see Container.configure
+        #
+        # @!method add_to_load_path
+        #
+        #   Returns the configured value.
+        #
+        #   @return [Boolean]
+        #
+        #   @see add_to_load_path=
         setting :add_to_load_path, true
+
+        # @!method default_namespace=(leading_namespace)
+        #
+        #   Sets the leading namespace segments to be stripped when registering components
+        #   from the dir in the container.
+        #
+        #   This is useful to configure when the dir contains components in a module
+        #   namespace that you don't want repeated in their identifiers.
+        #
+        #   Defaults to `nil`.
+        #
+        #   @param leading_namespace [String, nil]
+        #   @return [String, nil]
+        #
+        #   @example
+        #     dir.default_namespace = "my_app"
+        #
+        #   @example
+        #     dir.default_namespace = "my_app.admin"
+        #
+        #   @see default_namespace
+        #
+        # @!method default_namespace
+        #
+        #   Returns the configured value.
+        #
+        #   @return [String, nil]
+        #
+        #   @see default_namespace=
         setting :default_namespace
+
+        # @!method loader=(loader)
+        #
+        #   Sets the loader to use when registering coponents from the dir in the container.
+        #
+        #   Defaults to `Dry::System::Loader`.
+        #
+        #   When using a class autoloader, consider using `Dry::System::Loader::Autoloading`
+        #
+        #   @param loader [#call] the loader
+        #   @return [#call] the configured loader
+        #
+        #   @see loader
+        #   @see Loader
+        #   @see Loader::Autoloading
+        #
+        # @!method loader
+        #
+        #   Returns the configured loader.
+        #
+        #   @return [#call]
+        #
+        #   @see loader=
         setting :loader, Dry::System::Loader
+
+        # @!method memoize=(policy)
+        #
+        #   Sets whether to memoize components from the dir when registered in the
+        #   container.
+        #
+        #   This may be a simple boolean to enable or disable memoization for all
+        #   components, or a proc accepting a `Dry::Sytem::Component` and returning a
+        #   boolean to configure memoization on a per-component basis
+        #
+        #   Defaults to `false`.
+        #
+        #   @param policy [Boolean, Proc]
+        #   @return [Boolean, Proc] the configured memoization policy
+        #
+        #   @example
+        #     dir.memoize = true
+        #
+        #   @example
+        #     dir.memoize = proc do |component|
+        #       !component.start_with?("providers")
+        #     end
+        #
+        #   @see memoize
+        #   @see Component
+        #
+        # @!method memoize
+        #
+        #   Returns the configured memoization policy.
+        #
+        #   @return [Boolean, Proc] the configured memoization policy
+        #
+        #   @see memoize=
         setting :memoize, false
 
+        # @!endgroup
+
+        # Returns the component dir path, relative to the configured container root
+        #
+        # @return [String] the path
         attr_reader :path
 
+        # @api private
         def initialize(path)
           super()
           @path = path
           yield self if block_given?
         end
 
+        # @api private
         def auto_register?
           !!config.auto_register
         end

--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -172,6 +172,17 @@ module Dry
           !!config.auto_register
         end
 
+        # Returns true if a setting has been explicitly configured and is not returning
+        # just a default value.
+        #
+        # This is used to determine which settings from `ComponentDirs` should be applied
+        # as additional defaults.
+        #
+        # @api private
+        def configured?(key)
+          config._settings[key].input_defined?
+        end
+
         private
 
         def method_missing(name, *args, &block)

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -10,9 +10,10 @@ module Dry
       class ComponentDirs
         include Dry::Configurable
 
-        # Settings from ComponentDir can be configured here to apply all added dirs as
-        # defaults
-        @_settings = ComponentDir._settings.dup
+        # Settings from ComponentDir are configured here as defaults for all added dirs
+        ComponentDir._settings.each do |setting|
+          _settings << setting.dup
+        end
 
         # @!group Settings
 

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -2,7 +2,6 @@ require "concurrent/map"
 require "dry/configurable"
 require "dry/system/constants"
 require "dry/system/errors"
-require "dry/system/loader"
 require_relative "component_dir"
 
 module Dry
@@ -11,11 +10,8 @@ module Dry
       class ComponentDirs
         include Dry::Configurable
 
-        setting :auto_register, true
-        setting :add_to_load_path, true
-        setting :default_namespace
-        setting :loader, Dry::System::Loader
-        setting :memoize, false
+        # Component dirs settings can be configured here to apply as defaults to all dirs
+        @_settings = ComponentDir._settings.dup
 
         def initialize
           @dirs = Concurrent::Map.new

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -1,6 +1,7 @@
 require "concurrent/map"
 require "dry/configurable"
 require "dry/system/errors"
+require "dry/system/loader"
 require_relative "component_dir"
 
 module Dry
@@ -12,7 +13,7 @@ module Dry
         setting :auto_register, true
         setting :add_to_load_path, true
         setting :default_namespace
-        setting :loader
+        setting :loader, Dry::System::Loader
         setting :memoize, false
 
         attr_reader :dirs

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -10,18 +10,105 @@ module Dry
       class ComponentDirs
         include Dry::Configurable
 
-        # Component dirs settings can be configured here to apply as defaults to all dirs
+        # Settings from ComponentDir can be configured here to apply all added dirs as
+        # defaults
         @_settings = ComponentDir._settings.dup
 
+        # @!group Settings
+
+        # @!method auto_register=(value)
+        #
+        #   Sets a default `auto_register` for all added component dirs
+        #
+        #   @see ComponentDir.auto_register
+        #   @see auto_register
+        #
+        # @!method auto_register
+        #
+        #   Returns the configured default `auto_register`
+        #
+        #   @see auto_register=
+
+        # @!method add_to_load_path=(value)
+        #
+        #   Sets a default `add_to_load_path` value for all added component dirs
+        #
+        #   @see ComponentDir.add_to_load_path
+        #   @see add_to_load_path
+        #
+        # @!method add_to_load_path
+        #
+        #   Returns the configured default `add_to_load_path`
+        #
+        #   @see add_to_load_path=
+
+        # @!method default_namespace=(value)
+        #
+        #   Sets a default `default_namespace` value for all added component dirs
+        #
+        #   @see ComponentDir.default_namespace
+        #   @see default_namespace
+        #
+        # @!method default_namespace
+        #
+        #   Returns the configured default `default_namespace`
+        #
+        #   @see default_namespace=
+
+        # @!method loader=(value)
+        #
+        #   Sets a default `loader` value for all added component dirs
+        #
+        #   @see ComponentDir.loader
+        #   @see loader
+        #
+        # @!method loader
+        #
+        #   Returns the configured default `loader`
+        #
+        #   @see loader=
+
+        # @!method memoize=(value)
+        #
+        #   Sets a default `memoize` value for all added component dirs
+        #
+        #   @see ComponentDir.memoize
+        #   @see memoize
+        #
+        # @!method memoize
+        #
+        #   Returns the configured default `memoize`
+        #
+        #   @see memoize=
+
+        # @!endgroup
+
+        # @api private
         def initialize
           @dirs = Concurrent::Map.new
         end
 
+        # @api private
         def initialize_copy(source)
           super
           @dirs = source.dirs.dup
         end
 
+        # Adds and configures a component dir
+        #
+        # @param path [String] the path for the component dir, relative to the configured
+        #   container root
+        #
+        # @yieldparam dir [ComponentDir] the component dir to configure
+        #
+        # @return [ComponentDir] the added component dir
+        #
+        # @example
+        #   component_dirs.add "lib" do |dir|
+        #     dir.default_namespace = "my_app"
+        #   end
+        #
+        # @see ComponentDir
         def add(path)
           raise ComponentDirAlreadyAddedError, path if dirs.key?(path)
 
@@ -30,14 +117,24 @@ module Dry
           end
         end
 
+        # Returns the added component dirs, with default settings applied
+        #
+        # @return [Hash<String, ComponentDir>] the component dirs as a hash, keyed by path
         def dirs
           @dirs.each { |_, dir| apply_defaults_to_dir(dir) }
         end
 
+        # Returns the added component dirs, with default settings applied
+        #
+        # @return [Array<ComponentDir>]
         def to_a
           dirs.values
         end
 
+        # Calls the given block once for each added component dir, passing the dir as an
+        # argument.
+        #
+        # @yieldparam dir [ComponentDir] the yielded component dir
         def each(&block)
           to_a.each(&block)
         end
@@ -45,7 +142,8 @@ module Dry
         private
 
         # Apply default settings to a component dir. This is run every time the dirs are
-        # accessed, so this must be idempotent
+        # accessed to ensure defaults are applied regardless of when new component dirs
+        # are added. This method must be idempotent.
         #
         # @return [void]
         def apply_defaults_to_dir(dir)

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -11,7 +11,6 @@ require "dry/core/deprecations"
 
 require "dry/system"
 require "dry/system/errors"
-require "dry/system/loader"
 require "dry/system/booter"
 require "dry/system/auto_registrar"
 require "dry/system/manual_registrar"
@@ -80,7 +79,6 @@ module Dry
       setting :registrations_dir, "container"
       setting :component_dirs, Config::ComponentDirs.new, cloneable: true
       setting :inflector, Dry::Inflector.new
-      setting :loader, Dry::System::Loader
       setting :booter, Dry::System::Booter
       setting :auto_registrar, Dry::System::AutoRegistrar
       setting :manual_registrar, Dry::System::ManualRegistrar

--- a/spec/integration/container/autoloading_spec.rb
+++ b/spec/integration/container/autoloading_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "Autoloading loader" do
     module Test
       class Container < Dry::System::Container
         config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
+        config.component_dirs.loader = Dry::System::Loader::Autoloading
         config.component_dirs.add "lib" do |dir|
           dir.add_to_load_path = false
           dir.default_namespace = "test"
         end
-        config.loader = Dry::System::Loader::Autoloading
       end
     end
 

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -22,12 +22,21 @@ RSpec.describe Dry::System::Config::ComponentDirs do
       expect(dir.add_to_load_path).to eq false
     end
 
-    it "applies default values" do
+    it "applies default values configured previously" do
       component_dirs.default_namespace = "global_default"
+
       component_dirs.add "test/path"
 
       dir = component_dirs.dirs["test/path"]
+      expect(dir.default_namespace).to eq "global_default"
+    end
 
+    it "applies default values configured after adding" do
+      component_dirs.add "test/path"
+
+      component_dirs.default_namespace = "global_default"
+
+      dir = component_dirs.dirs["test/path"]
       expect(dir.default_namespace).to eq "global_default"
     end
 

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -5,39 +5,30 @@ RSpec.describe Dry::System::Config::ComponentDirs do
   subject(:component_dirs) { described_class.new }
 
   describe "#add" do
-    context "adding and configuring a component dir" do
-      it "adds the component dir based on the provided configuration" do
-        expect {
-          component_dirs.add "test/path" do |dir|
-            dir.auto_register = false
-            dir.add_to_load_path = false
-          end
-        }
-          .to change { component_dirs.dirs.keys.length }
-          .from(0).to(1)
-
-        dir = component_dirs.dirs["test/path"]
-
-        expect(dir.path).to eq "test/path"
-        expect(dir.auto_register).to eq false
-        expect(dir.add_to_load_path).to eq false
-      end
-    end
-
-    context "adding an already-configured component dir" do
-      it "adds the component dir" do
-        component_dir = Dry::System::Config::ComponentDir.new("test/path") do |dir|
+    it "adds the component dir based on the provided configuration" do
+      expect {
+        component_dirs.add "test/path" do |dir|
           dir.auto_register = false
           dir.add_to_load_path = false
         end
+      }
+        .to change { component_dirs.dirs.keys.length }
+        .from(0).to(1)
 
-        expect { component_dirs.add component_dir }
-          .to change { component_dirs.dirs.keys.length }
-          .from(0)
-          .to(1)
+      dir = component_dirs.dirs["test/path"]
 
-        expect(component_dirs.dirs["test/path"]).to eql component_dir
-      end
+      expect(dir.path).to eq "test/path"
+      expect(dir.auto_register).to eq false
+      expect(dir.add_to_load_path).to eq false
+    end
+
+    it "applies default values" do
+      component_dirs.default_namespace = "global_default"
+      component_dirs.add "test/path"
+
+      dir = component_dirs.dirs["test/path"]
+
+      expect(dir.default_namespace).to eq "global_default"
     end
 
     context "component dir already added" do

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Dry::System::Config::ComponentDirs do
       expect(dir.add_to_load_path).to eq false
     end
 
-    it "applies default values configured previously" do
+    it "applies default values configured before adding" do
       component_dirs.default_namespace = "global_default"
 
       component_dirs.add "test/path"
@@ -38,6 +38,21 @@ RSpec.describe Dry::System::Config::ComponentDirs do
 
       dir = component_dirs.dirs["test/path"]
       expect(dir.default_namespace).to eq "global_default"
+    end
+
+    it "does not apply default values over the component dir's own config" do
+      component_dirs.default_namespace = "global_default"
+      component_dirs.memoize = true
+
+      component_dirs.add "test/path" do |dir|
+        dir.default_namespace = nil
+        dir.memoize = false
+      end
+
+      dir = component_dirs.dirs["test/path"]
+
+      expect(dir.default_namespace).to be nil
+      expect(dir.memoize).to be false
     end
 
     context "component dir already added" do

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -90,10 +90,10 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       class Test::Container < Dry::System::Container
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs.loader = Test::Loader
           config.component_dirs.add "components" do |dir|
             dir.default_namespace = "test"
           end
-          config.loader = Test::Loader
         end
       end
     end


### PR DESCRIPTION
This PR rounds out the work done in #155, #157, and #158, and makes it possible to configure default values for all component dir settings directly on the container's `config.component_dirs`. For example:

```ruby
config.component_dirs.loader = MyCustomLoader
config.component_dirs.default_namespace = "my_app"

# This dir will have the above values applied as defaults
config.component_dirs.add "lib"
```

This will be particularly useful e.g. for users configuring dry-system to work with an class autoloader like Zeitwerk, which would require the following defaults to be applied:

```ruby
config.component_dirs.loader = Dry::System::Loader::Autoloading
config.component_dirs.add_to_load_path = false
```

Having to configure these manually for every added component dir would be a suboptimal configuration experience. Further, the existence of these default settings will make it possible for us to create a plugin to enable a simple `use :zeitwerk` one-liner in the future.

It should be noted that the order of configuring the defaults and adding component dirs does not matter. The defaults will be applied to added component dirs regardless of whether they have been configured before or after the dirs are added.

Along with this, this PR fleshes out the API documentation for `Dry::System::Config::ComponentDirs` and `Dry::System::Config::ComponentDir`.

**This introduces one more BREAKING CHANGE** for the upcoming release: the top-level `loader` setting has been removed, with a system-wide loader now possible to configure via `component_dirs.loader`.

FYI, I plan to squash all commits here when merging.