### PR TITLE
Cast identifier to String during initialization

### DIFF
--- a/lib/dry/system/identifier.rb
+++ b/lib/dry/system/identifier.rb
@@ -29,7 +29,7 @@ module Dry
 
       # @api private
       def initialize(identifier, namespace: nil, separator: DEFAULT_SEPARATOR)
-        @identifier = identifier
+        @identifier = identifier.to_s
         @namespace = namespace
         @separator = separator
       end

--- a/spec/unit/identifier_spec.rb
+++ b/spec/unit/identifier_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Dry::System::Identifier do
   let(:namespace) { "my_app" }
   let(:separator) { "." }
 
+  it "casts identifier to string" do
+    expect(described_class.new(:db).identifier).to eq "db"
+  end
+
   describe "#identifier" do
     it "is the identifier string in full" do
       expect(identifier.identifier).to eq "kittens.operations.belly_rub"


### PR DESCRIPTION
The `identifier` of an `Identifier` is expected to be a String, but occasionally it might be a symbol passed through from `dry-container`. To be safe, cast it during initialization of the `Identifier` class.

This fixes a bug where resolving an unknown component provided as a Symbol (vs a String) would cause `gsub` `NoMethodError` error on `Symbol` and not the correct user-facing error about the component not being found.

Reproduction
```ruby
require "dry/system/container"

class Application < Dry::System::Container
  configure do |config|
    config.component_dirs.add "lib"
  end
end

Application[:db]
```

Exception backtrace
```
/usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/identifier.rb:78:in `path': undefined method `gsub' for :db:Symbol (NoMethodError)
        from /usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/component_dir.rb:48:in `component_for_identifier'
        from /usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/container.rb:634:in `block in component'
        from /usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/container.rb:633:in `each'
        from /usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/container.rb:633:in `detect'
        from /usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/container.rb:633:in `component'
        from /usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/container.rb:585:in `load_component'
        from /usr/local/bundle/bundler/gems/dry-system-7eb624a6ff65/lib/dry/system/container.rb:486:in `resolve'
        from /usr/local/bundle/gems/dry-container-0.7.2/lib/dry/container/mixin.rb:134:in `[]'
        from application.rb:9:in `<main>'
```