### PR TITLE
Check for actual registered string keys in AutoRegistrar

### DIFF
--- a/lib/dry/system/auto_registrar.rb
+++ b/lib/dry/system/auto_registrar.rb
@@ -32,7 +32,7 @@ module Dry
         components(component_dir).each do |component|
           next unless register_component?(component)
 
-          container.register(component.identifier, memoize: component.memoize?) { component.instance }
+          container.register(component.key, memoize: component.memoize?) { component.instance }
         end
       end
 
@@ -51,7 +51,7 @@ module Dry
       end
 
       def register_component?(component)
-        !container.registered?(component) && component.auto_register?
+        !container.registered?(component.key) && component.auto_register?
       end
     end
   end

--- a/spec/unit/auto_registrar_spec.rb
+++ b/spec/unit/auto_registrar_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "dry/system/auto_registrar"
+
+RSpec.describe Dry::System::AutoRegistrar, "#finalize!" do
+  let(:auto_registrar) { described_class.new(container) }
+
+  let(:container) {
+    Class.new(Dry::System::Container) {
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures").realpath
+        config.component_dirs.add "components" do |dir|
+          dir.default_namespace = "test"
+        end
+      end
+    }
+  }
+
+  it "registers components in the configured component dirs" do
+    auto_registrar.finalize!
+
+    expect(container["foo"]).to be_an_instance_of(Test::Foo)
+    expect(container["bar"]).to be_an_instance_of(Test::Bar)
+    expect(container["bar.baz"]).to be_an_instance_of(Test::Bar::Baz)
+  end
+
+  it "doesn't re-register components previously registered via lazy loading" do
+    expect(container["foo"]).to be_an_instance_of(Test::Foo)
+
+    expect { auto_registrar.finalize! }.not_to raise_error
+
+    expect(container["bar"]).to be_an_instance_of(Test::Bar)
+    expect(container["bar.baz"]).to be_an_instance_of(Test::Bar::Baz)
+  end
+end


### PR DESCRIPTION
This prevents "There is already an item registered with the key" Dry::Container::Error exceptions from being raised when finalizing the container after already having lazily loaded a few components.

This PR includes a new test case that would fail with the previous behaviour.