### PR TITLE
Update finalize! signature in Container::Stubs

### DIFF
--- a/lib/dry/system/stubs.rb
+++ b/lib/dry/system/stubs.rb
@@ -7,7 +7,7 @@ module Dry
     class Container
       # @api private
       module Stubs
-        def finalize!(&block)
+        def finalize!(freeze: true, &block)
           super(freeze: false, &block)
         end
       end


### PR DESCRIPTION
Currently Container.enable_stubs! causes Container.finalize! signature to change:
method no longer accepts "freeze" keyword argument. This causes consumers that
rely on this api to crash, i.e. dry-rails railtie