### PR TITLE
Update for latest dry-configurable

### DIFF
--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -40,7 +40,7 @@ module Dry
         #   @return [Boolean, Proc] the configured policy
         #
         #   @see auto_register=
-        setting :auto_register, true
+        setting :auto_register, default: true
 
         # @!method add_to_load_path=(policy)
         #
@@ -63,7 +63,7 @@ module Dry
         #   @return [Boolean]
         #
         #   @see add_to_load_path=
-        setting :add_to_load_path, true
+        setting :add_to_load_path, default: true
 
         # @!method default_namespace=(leading_namespace)
         #
@@ -117,7 +117,7 @@ module Dry
         #   @return [#call]
         #
         #   @see loader=
-        setting :loader, Dry::System::Loader
+        setting :loader, default: Dry::System::Loader
 
         # @!method memoize=(policy)
         #
@@ -151,7 +151,7 @@ module Dry
         #   @return [Boolean, Proc] the configured memoization policy
         #
         #   @see memoize=
-        setting :memoize, false
+        setting :memoize, default: false
 
         # @!endgroup
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -7,6 +7,7 @@ require "dry-configurable"
 require "dry-container"
 require "dry/inflector"
 
+require "dry/core/constants"
 require "dry/core/deprecations"
 
 require "dry/system"
@@ -73,17 +74,17 @@ module Dry
       extend Dry::System::Plugins
 
       setting :name
-      setting(:root, Pathname.pwd.freeze) { |path| Pathname(path) }
-      setting :system_dir, "system"
-      setting :bootable_dirs, ["system/boot"]
-      setting :registrations_dir, "container"
-      setting :component_dirs, Config::ComponentDirs.new, cloneable: true
-      setting :inflector, Dry::Inflector.new
-      setting :booter, Dry::System::Booter
-      setting :auto_registrar, Dry::System::AutoRegistrar
-      setting :manual_registrar, Dry::System::ManualRegistrar
-      setting :importer, Dry::System::Importer
-      setting(:components, {}, reader: true, &:dup)
+      setting :root, default: Pathname.pwd.freeze, constructor: -> path { Pathname(path) }
+      setting :system_dir, default: "system"
+      setting :bootable_dirs, default: ["system/boot"]
+      setting :registrations_dir, default: "container"
+      setting :component_dirs, default: Config::ComponentDirs.new, cloneable: true
+      setting :inflector, default: Dry::Inflector.new
+      setting :booter, default: Dry::System::Booter
+      setting :auto_registrar, default: Dry::System::AutoRegistrar
+      setting :manual_registrar, default: Dry::System::ManualRegistrar
+      setting :importer, default: Dry::System::Importer
+      setting :components, default: {}, reader: true, constructor: :dup.to_proc
 
       class << self
         def strategies(value = nil)
@@ -101,8 +102,8 @@ module Dry
         # @see https://dry-rb.org/gems/dry-configurable
         #
         # @api public
-        def setting(name, *args, &block)
-          super(name, *args, &block)
+        def setting(name, default = Dry::Core::Constants::Undefined, **options, &block)
+          super(name, default, **options, &block)
           # TODO: dry-configurable needs a public API for this
           config._settings << _settings[name]
           self

--- a/lib/dry/system/plugins/bootsnap.rb
+++ b/lib/dry/system/plugins/bootsnap.rb
@@ -16,7 +16,7 @@ module Dry
         def self.extended(system)
           super
           system.use(:env)
-          system.before(:configure) { setting :bootsnap, DEFAULT_OPTIONS }
+          system.before(:configure) { setting :bootsnap, default: DEFAULT_OPTIONS }
           system.after(:configure, &:setup_bootsnap)
         end
 

--- a/lib/dry/system/plugins/dependency_graph.rb
+++ b/lib/dry/system/plugins/dependency_graph.rb
@@ -15,7 +15,7 @@ module Dry
           system.use(:notifications)
 
           system.before(:configure) do
-            setting :ignored_dependencies, []
+            setting :ignored_dependencies, default: []
           end
 
           system.after(:configure) do

--- a/lib/dry/system/plugins/env.rb
+++ b/lib/dry/system/plugins/env.rb
@@ -20,7 +20,7 @@ module Dry
 
         # @api private
         def extended(system)
-          system.setting :env, inferrer.(), reader: true
+          system.setting :env, default: inferrer.(), reader: true
           super
         end
       end

--- a/lib/dry/system/plugins/logging.rb
+++ b/lib/dry/system/plugins/logging.rb
@@ -11,14 +11,15 @@ module Dry
           system.before(:configure) do
             setting :logger, reader: true
 
-            setting :log_dir, "log"
+            setting :log_dir, default: "log"
 
-            setting :log_levels,
-                    development: Logger::DEBUG,
-                    test: Logger::DEBUG,
-                    production: Logger::ERROR
+            setting :log_levels, default: {
+              development: Logger::DEBUG,
+              test: Logger::DEBUG,
+              production: Logger::ERROR
+            }
 
-            setting :logger_class, ::Logger, reader: true
+            setting :logger_class, default: ::Logger, reader: true
           end
 
           system.after(:configure, &:register_logger)

--- a/spec/integration/container/plugins_spec.rb
+++ b/spec/integration/container/plugins_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Dry::System::Container, ".use" do
       before do
         Dry::System::Plugins.register(:test_plugin, plugin) do
           before(:configure) do
-            setting(:trace, [])
+            setting :trace, default: []
           end
 
           after(:configure) do


### PR DESCRIPTION
This uses the new kwargs for the `setting` API, as well as updating our local override of the setting method to match its new params signature (it would be nice to see if we could remove that override, but that's a job for a separate PR).

This fix will be necessary to have in place by the time we release dry-configurable, since without these changes, the specs fail with the dry-configurable's master branch right now.