### PR TITLE
Renamed setting dsl method key to setting

### DIFF
--- a/docsite/source/component-providers.html.md
+++ b/docsite/source/component-providers.html.md
@@ -84,8 +84,8 @@ Here's an extended `:exception_notifier` example which uses its own settings:
 #  |- lib/my_gem/boot/exception_notifier.rb
 Dry::System.register_component(:exception_notifier, provider: :common) do
   settings do
-    key :environments, Types::Strict::Array.of(Types::Strict::Symbol).default(%i[production])
-    key :logger, Types::Any
+    setting :environments, Types::Strict::Array.of(Types::Strict::Symbol).default(%i[production])
+    setting :logger, Types::Any
   end
 
   init do

--- a/docsite/source/settings.html.md
+++ b/docsite/source/settings.html.md
@@ -15,8 +15,8 @@ require "path/to/dry/types/file"
 
 Application.boot(:settings, from: :system) do
   settings do
-    key :database_url, Types::String.constrained(filled: true)
-    key :logger_level, Types::Symbol.constructor(proc { |value| value.to_s.downcase.to_sym })
+    setting :database_url, Types::String.constrained(filled: true)
+    setting :logger_level, Types::Symbol.constructor(proc { |value| value.to_s.downcase.to_sym })
                                     .default(:info)
                                     .enum(:trace, :unknown, :error, :fatal, :warn, :info, :debug)
   end
@@ -67,7 +67,7 @@ You can [use dry-types](https://dry-rb.org/gems/dry-types/master/default-values/
 
 ```ruby
 settings do
-  key :redis_url, Types::Coercible::String.default('')
+  setting :redis_url, Types::Coercible::String.default('')
 end
 ```
 

--- a/lib/dry/system/components/bootable.rb
+++ b/lib/dry/system/components/bootable.rb
@@ -35,8 +35,8 @@ module Dry
       #   class App < Dry::System::Container
       #     boot(:settings, from: :system) do
       #       settings do
-      #         key :database_url, Types::String.constrained(filled: true)
-      #         key :session_secret, Types::String.constrained(filled: true)
+      #         setting :database_url, Types::String.constrained(filled: true)
+      #         setting :session_secret, Types::String.constrained(filled: true)
       #       end
       #     end
       #   end

--- a/lib/dry/system/settings.rb
+++ b/lib/dry/system/settings.rb
@@ -29,9 +29,18 @@ module Dry
           end
         end
 
-        def key(name, type)
+        def setting(name, type)
+          if ::Kernel::__callee__ == :key
+            ::Dry::Core::Deprecations.announce(
+              "the name of this method will be renamed to :settings",
+              "Please refactor your call at #{::Kernel::caller[0]}",
+              tag: "dry-system",
+              uplevel: 2
+            )
+          end
           schema[name] = type
         end
+        alias :key :setting
       end
 
       class Configuration < Dry::Struct

--- a/spec/fixtures/external_components/components/logger.rb
+++ b/spec/fixtures/external_components/components/logger.rb
@@ -4,7 +4,7 @@ require "dry/system"
 
 Dry::System.register_component(:logger, provider: :external_components) do
   settings do
-    key :log_level, Types::Symbol.default(:scream)
+    setting :log_level, Types::Symbol.default(:scream)
   end
 
   init do

--- a/spec/integration/boot_spec.rb
+++ b/spec/integration/boot_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Dry::System::Container, ".boot" do
     it "uses defaults" do
       system.boot(:api) do
         settings do
-          key :token, Types::String.default("xxx")
+          setting :token, Types::String.default("xxx")
         end
 
         start do

--- a/spec/integration/settings_component_spec.rb
+++ b/spec/integration/settings_component_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Settings component" do
         end
 
         settings do
-          key :database_url, SettingsTest::Types::String.constrained(filled: true)
-          key :session_secret, SettingsTest::Types::String.constrained(filled: true)
+          setting :database_url, SettingsTest::Types::String.constrained(filled: true)
+          setting :session_secret, SettingsTest::Types::String.constrained(filled: true)
         end
       end
     end
@@ -58,8 +58,8 @@ RSpec.describe "Settings component" do
           end
 
           settings do
-            key :integer_value, SettingsTest::Types::Strict::Integer
-            key :coercible_value, SettingsTest::Types::Coercible::Integer
+            setting :integer_value, SettingsTest::Types::Strict::Integer
+            setting :coercible_value, SettingsTest::Types::Coercible::Integer
           end
         end
       end
@@ -106,7 +106,7 @@ RSpec.describe "Settings component" do
           end
 
           settings do
-            key :number_of_workers, SettingsTest::Types::Coercible::Integer.default(14)
+            setting :number_of_workers, SettingsTest::Types::Coercible::Integer.default(14)
           end
         end
       end


### PR DESCRIPTION
@timriley mentioned in the [ticket 166](https://github.com/dry-rb/dry-system/issues/166) that the setting DSL method key should be renamed to setting, which is done in this pr