### PR TITLE
Fix settings component example code

### DIFF
--- a/docsite/source/settings.html.md
+++ b/docsite/source/settings.html.md
@@ -16,7 +16,7 @@ require "path/to/dry/types/file"
 Application.boot(:settings, from: :system) do
   settings do
     key :database_url, Types::String.constrained(filled: true)
-    key :logger_level, Types::Symbol.constructor(Kernel.proc { |value| value.to_s.downcase.to_sym })
+    key :logger_level, Types::Symbol.constructor { |value| value.to_s.downcase.to_sym }
                                     .default(:info)
                                     .enum(:trace, :unknown, :error, :fatal, :warn, :info, :debug)
   end

--- a/docsite/source/settings.html.md
+++ b/docsite/source/settings.html.md
@@ -16,7 +16,7 @@ require "path/to/dry/types/file"
 Application.boot(:settings, from: :system) do
   settings do
     key :database_url, Types::String.constrained(filled: true)
-    key :logger_level, Types::Symbol.constructor(proc { |value| value.to_s.downcase.to_sym })
+    key :logger_level, Types::Symbol.constructor(Kernel.proc { |value| value.to_s.downcase.to_sym })
                                     .default(:info)
                                     .enum(:trace, :unknown, :error, :fatal, :warn, :info, :debug)
   end


### PR DESCRIPTION
Since `Dry::System::Settings::DSL` is a `BasicObject`, it doesn’t include `Kernel`, so `#proc` is not defined.
To get this example working, call `Kernel.proc` directly