### PR TITLE
Forbid direct write access to the config object

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -135,7 +135,6 @@ module Dry
 
         def config
           if @hooks_initialized != true && finalized? != true && @configure_self != true
-            klass = super
             super.instance_eval do
               def method_missing(meth, *args)
                 setting = _settings[resolve(meth)]
@@ -145,8 +144,9 @@ module Dry
                 else
                   super
                 end
-              end #unless super.respond_to?(:method_missing)
-            end
+              end
+            end if !@method_patched
+            @method_patched = true
           end
           super
         end

--- a/spec/integration/container/autoloading_spec.rb
+++ b/spec/integration/container/autoloading_spec.rb
@@ -11,11 +11,13 @@ RSpec.describe "Autoloading loader" do
 
     module Test
       class Container < Dry::System::Container
-        config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
-        config.component_dirs.loader = Dry::System::Loader::Autoloading
-        config.component_dirs.add "lib" do |dir|
-          dir.add_to_load_path = false
-          dir.default_namespace = "test"
+        configure do |config|
+          config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
+          config.component_dirs.loader = Dry::System::Loader::Autoloading
+          config.component_dirs.add "lib" do |dir|
+            dir.add_to_load_path = false
+            dir.default_namespace = "test"
+          end
         end
       end
     end

--- a/spec/integration/container/bootable_components/multiple_bootable_dirs_spec.rb
+++ b/spec/integration/container/bootable_components/multiple_bootable_dirs_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe "Bootable components / Multiple bootable dirs" do
   specify "Resolving boot files from multiple bootable dirs" do
     module Test
       class Container < Dry::System::Container
-        config.root = SPEC_ROOT.join("fixtures/multiple_bootable_dirs").realpath
+        configure do |config|
+          config.root = SPEC_ROOT.join("fixtures/multiple_bootable_dirs").realpath
+          config.bootable_dirs = [
+            "custom_bootables", # Relative paths are appended to the container root
+            SPEC_ROOT.join("fixtures/multiple_bootable_dirs/default_bootables")
+          ]
+        end
 
-        config.bootable_dirs = [
-          "custom_bootables", # Relative paths are appended to the container root
-          SPEC_ROOT.join("fixtures/multiple_bootable_dirs/default_bootables")
-        ]
       end
     end
 

--- a/spec/unit/container/hooks/load_path_hook_spec.rb
+++ b/spec/unit/container/hooks/load_path_hook_spec.rb
@@ -3,7 +3,9 @@
 RSpec.describe Dry::System::Container, "Default hooks / Load path" do
   let(:container) {
     Class.new(Dry::System::Container) {
-      config.root = SPEC_ROOT.join("fixtures/test")
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures/test")
+      end
     }
   }
 

--- a/spec/unit/container/load_path_spec.rb
+++ b/spec/unit/container/load_path_spec.rb
@@ -5,8 +5,10 @@ require "dry/system/container"
 RSpec.describe Dry::System::Container, "Load path handling" do
   let(:container) {
     class Test::Container < Dry::System::Container
-      config.root = SPEC_ROOT.join("fixtures/test")
-      config.component_dirs.add "lib"
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures/test")
+        config.component_dirs.add "lib"
+      end
     end
 
     Test::Container
@@ -28,7 +30,7 @@ RSpec.describe Dry::System::Container, "Load path handling" do
         .and change { $LOAD_PATH.include?(SPEC_ROOT.join("fixtures/test/system").to_s) }
         .from(false).to(true)
 
-      expect($LOAD_PATH[0..1]).to eq [
+      expect($LOAD_PATH[0..1].sort).to eq [
         SPEC_ROOT.join("fixtures/test/lib").to_s,
         SPEC_ROOT.join("fixtures/test/system").to_s
       ]

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -223,4 +223,24 @@ RSpec.describe Dry::System::Container do
       expect(container.registered?("test.dep")).to be(true)
     end
   end
+
+  describe ".configure" do
+    it "raises an exception if the config is set manually" do
+      expect{
+        class Test::Container < Dry::System::Container
+          config.root = SPEC_ROOT.join("fixtures/test").realpath
+        end
+      }.to raise_error("Config can't be accessed directly. Please use the #configure method")
+    end
+
+    it 'works if the config is set using the configure method' do
+      expect{
+        class Test::Container < Dry::System::Container
+          configure do |config|
+            config.root = SPEC_ROOT.join("fixtures/test").realpath
+          end
+        end
+      }.not_to raise_error("Config can't be accessed directly. Please use the #configure method")
+    end
+  end
 end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Dry::System::Container do
             config.root = SPEC_ROOT.join("fixtures/test").realpath
           end
         end
-      }.not_to raise_error("Config can't be accessed directly. Please use the #configure method")
+      }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Direct access to config isn't allowed anymore [ticket 159](https://github.com/dry-rb/dry-system/issues/159)

Tests are all green, but this still feels a little bit of sluggish.

Also, right now we never get rid of the newly defined method_missing and therefore it is *never* possible to directly write a config.

Feedback is very much appreciated!