### PR TITLE
Make compatibility fixes to support a future dry-configurable 0.13.0 release

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -107,6 +107,7 @@ module Dry
           config._settings << _settings[name]
           self
         end
+        ruby2_keywords(:setting) if respond_to?(:ruby2_keywords, true)
 
         # Configures the container
         #

--- a/lib/dry/system/plugins/logging.rb
+++ b/lib/dry/system/plugins/logging.rb
@@ -13,10 +13,7 @@ module Dry
 
             setting :log_dir, "log"
 
-            setting :log_levels,
-                    development: Logger::DEBUG,
-                    test: Logger::DEBUG,
-                    production: Logger::ERROR
+            setting :log_levels, {development: Logger::DEBUG, test: Logger::DEBUG, production: Logger::ERROR}
 
             setting :logger_class, ::Logger, reader: true
           end


### PR DESCRIPTION
This PR includes 2 changes:

- Use `ruby2_keywords` for our override of dry-configurable's `setting` method, to make sure it will still work to delegate to the original when provided "real" keyword arguments in newer Rubies 
- Update a setting in the logging plugin to provide a "real" hash literal (i.e. enclosed in curly braces) rather than rely on Ruby's implicit conversion of keyword args to a hash literal

With these changes in place, the dry-system test suite passes against both dry-configurable 0.12.1 (the latest released version) as well as the master branch (intended for release as 0.13.0), on both Ruby versions 3.0.1 and 2.7.3.

To prepare for the upcoming dry-configurable release (which is being planned for at https://github.com/dry-rb/dry-configurable/issues/120), we need to:

1. Review and merge this PR
2. Port these specific changes into the master branch too
3. Make an 0.19.2 release of dry-system with these changes included
4. Update any dry-rb gems currently depending on dry-system to require at least version 0.19.2 (maybe this is not needed, since we could just have documentation that encourages users to upgrade dry-system as a transitive dependency?)
5. Complete the dry-configurable testing process and release 0.13.0