### PR TITLE
Make compatibility fixes to support a future dry-configurable 0.13.0 release (for 0.18 series for releases)

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -107,6 +107,7 @@ module Dry
           config._settings << _settings[name]
           self
         end
+        ruby2_keywords(:setting) if respond_to?(:ruby2_keywords, true)
 
         # Configures the container
         #

--- a/lib/dry/system/plugins/logging.rb
+++ b/lib/dry/system/plugins/logging.rb
@@ -13,10 +13,7 @@ module Dry
 
             setting :log_dir, "log"
 
-            setting :log_levels,
-                    development: Logger::DEBUG,
-                    test: Logger::DEBUG,
-                    production: Logger::ERROR
+            setting :log_levels, {development: Logger::DEBUG, test: Logger::DEBUG, production: Logger::ERROR}
 
             setting :logger_class, ::Logger, reader: true
           end


### PR DESCRIPTION
This PR takes the changes from #186 and backports them on top of the most recent 0.18 series release, 0.18.1.

This will permit new releases of both the 0.18 and 0.19 series to ensure they both work with the upcoming dry-configurable 0.13.0.