### PR TITLE
Broader interfaces to Config::ComponentDirs and Config::Namespaces

### DIFF
--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -9,6 +9,7 @@ require_relative "namespaces"
 module Dry
   module System
     module Config
+      # @api public
       class ComponentDir
         include Dry::Configurable
 
@@ -37,6 +38,7 @@ module Dry
         #
         #   @see auto_register
         #   @see Component
+        #   @api public
         #
         # @!method auto_register
         #
@@ -45,6 +47,7 @@ module Dry
         #   @return [Boolean, Proc] the configured policy
         #
         #   @see auto_register=
+        #   @api public
         setting :auto_register, default: true
 
         # @!method add_to_load_path=(policy)
@@ -60,6 +63,7 @@ module Dry
         #
         #   @see add_to_load_path
         #   @see Container.configure
+        #   @api public
         #
         # @!method add_to_load_path
         #
@@ -68,6 +72,7 @@ module Dry
         #   @return [Boolean]
         #
         #   @see add_to_load_path=
+        #   @api public
         setting :add_to_load_path, default: true
 
         # @!method loader=(loader)
@@ -85,6 +90,7 @@ module Dry
         #   @see loader
         #   @see Loader
         #   @see Loader::Autoloading
+        #   @api public
         #
         # @!method loader
         #
@@ -93,6 +99,7 @@ module Dry
         #   @return [#call]
         #
         #   @see loader=
+        #   @api public
         setting :loader, default: Dry::System::Loader
 
         # @!method memoize=(policy)
@@ -119,6 +126,7 @@ module Dry
         #
         #   @see memoize
         #   @see Component
+        #   @api public
         #
         # @!method memoize
         #
@@ -127,6 +135,7 @@ module Dry
         #   @return [Boolean, Proc] the configured memoization policy
         #
         #   @see memoize=
+        #   @api public
         setting :memoize, default: false
 
         # @!method namespaces
@@ -135,11 +144,13 @@ module Dry
         #
         #   Allows namespaces to added on the returned object via {Namespaces#add}.
         #
-        #   @see Namespaces#add
-        #
         #   @return [Namespaces] the namespaces
+        #
+        #   @see Namespaces#add
+        #   @api public
         setting :namespaces, default: Namespaces.new, cloneable: true
 
+        # @api public
         def default_namespace=(namespace)
           Dry::Core::Deprecations.announce(
             "Dry::System::Config::ComponentDir#default_namespace=",
@@ -157,6 +168,7 @@ module Dry
           namespaces.add namespace_path, key: nil
         end
 
+        # @api public
         def default_namespace
           Dry::Core::Deprecations.announce(
             "Dry::System::Config::ComponentDir#default_namespace",
@@ -179,7 +191,7 @@ module Dry
         # @return [String] the path
         attr_reader :path
 
-        # @api private
+        # @api public
         def initialize(path)
           super()
           @path = path

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -189,6 +189,7 @@ module Dry
         def length
           dirs.length
         end
+        alias_method :size, :length
 
         # Returns the added component dirs, with default settings applied
         #

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -109,7 +109,7 @@ module Dry
         #
         # @see ComponentDir
         def add(path_or_dir)
-          path, dir_to_add = prepare_to_add(path_or_dir)
+          path, dir_to_add = path_and_dir(path_or_dir)
 
           # TODO: is this worth even raising?
           raise ComponentDirAlreadyAddedError, path if dirs.key?(path)
@@ -117,16 +117,6 @@ module Dry
           dirs[path] = dir_to_add.tap do |dir|
             yield dir if block_given?
             apply_defaults_to_dir(dir)
-          end
-        end
-
-        private def prepare_to_add(path_or_dir)
-          if path_or_dir.is_a?(ComponentDir)
-            dir = path_or_dir
-            [dir.path, dir]
-          else
-            path = path_or_dir
-            [path, ComponentDir.new(path)]
           end
         end
 
@@ -167,6 +157,17 @@ module Dry
         end
 
         private
+
+        # TODO docs
+        def path_and_dir(path_or_dir)
+          if path_or_dir.is_a?(ComponentDir)
+            dir = path_or_dir
+            [dir.path, dir]
+          else
+            path = path_or_dir
+            [path, ComponentDir.new(path)]
+          end
+        end
 
         # Applies default settings to a component dir. This is run every time the dirs are
         # accessed to ensure defaults are applied regardless of when new component dirs

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -223,9 +223,7 @@ module Dry
         # @return Hash<String, ComponentDir>
         #
         # @api private
-        def dirs
-          @dirs
-        end
+        attr_reader :dirs
 
         private
 

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -140,6 +140,20 @@ module Dry
           end
         end
 
+        def dir(path)
+          @dirs.fetch(path).tap do |dir|
+            yield dir if block_given?
+          end
+        end
+
+        def remove(path)
+          @dirs.delete(path)
+        end
+
+        def paths
+          @dirs.keys
+        end
+
         # Returns the added component dirs, with default settings applied
         #
         # @return [Hash<String, ComponentDir>] the component dirs as a hash, keyed by path

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -65,6 +65,8 @@ module Dry
         #
         #   @see memoize=
 
+        # rubocop:disable Layout/LineLength
+
         # @!method namespaces
         #
         #   Returns the default configured namespaces for all added component dirs
@@ -74,6 +76,8 @@ module Dry
         #   @see Dry::System::Config::Namespaces#add
         #
         #   @return [Namespaces] the namespaces
+
+        # rubocop:enable Layout/LineLength
 
         # @!endgroup
 

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -108,12 +108,25 @@ module Dry
         #   end
         #
         # @see ComponentDir
-        def add(path)
+        def add(path_or_dir)
+          path, dir = prepare_to_add(path_or_dir)
+
+          # TODO: is this worth even raising?
           raise ComponentDirAlreadyAddedError, path if dirs.key?(path)
 
-          dirs[path] = ComponentDir.new(path).tap do |dir|
+          dirs[path] = dir.tap do |dir|
             yield dir if block_given?
             apply_defaults_to_dir(dir)
+          end
+        end
+
+        private def prepare_to_add(path_or_dir)
+          if path_or_dir.is_a?(ComponentDir)
+            dir = path_or_dir
+            [dir.path, dir]
+          else
+            path = path_or_dir
+            [path, ComponentDir.new(path)]
           end
         end
 

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -119,6 +119,13 @@ module Dry
           end
         end
 
+        # Returns and optionally yields a previously configured component dir
+        #
+        # @param path [String] the path for the component dir
+        #
+        # @yield param dir [ComponentDir] the component dir
+        #
+        # @return [ComponentDir] the component dir
         def dir(path)
           raise NoComponentDirError, path unless @dirs.key?(path)
 
@@ -127,6 +134,11 @@ module Dry
           end
         end
 
+        # Removes a previously configured component dir
+        #
+        # @param path [String] the path for the component dir
+        #
+        # @return [ComponentDir] the removed component dir
         def remove(path)
           @dirs.delete(path)
         end

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -69,9 +69,9 @@ module Dry
         #
         #   Returns the default configured namespaces for all added component dirs
         #
-        #   Allows namespaces to added on the returned object via {Namespaces#add}.
+        #   Allows namespaces to added on the returned object via {Dry::System::Config::Namespaces#add}.
         #
-        #   @see Namespaces#add
+        #   @see Dry::System::Config::Namespaces#add
         #
         #   @return [Namespaces] the namespaces
 
@@ -113,8 +113,6 @@ module Dry
             yield dir if block_given?
           end
         end
-
-        # (see #dir)
         alias_method :[], :dir
 
         # @overload add(path)
@@ -221,7 +219,7 @@ module Dry
         # This method exists to encapsulate the instance variable and to serve the needs
         # of #initialize_copy
         #
-        # @return Hash<String, ComponentDir>
+        # @return [Hash{String => ComponentDir}]
         #
         # @api private
         attr_reader :dirs
@@ -232,7 +230,7 @@ module Dry
         #
         # @param path_or_dir [String,ComponentDir]
         #
-        # @return Array<(String, ComponentDir)>
+        # @return [Array<(String, ComponentDir)>]
         #
         # @see #add
         def path_and_dir(path_or_dir)

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -90,7 +90,7 @@ module Dry
 
         # Creates a new component dirs
         #
-        # @api public
+        # @api private
         def initialize
           @dirs = {}
           @defaults = ComponentDir.new(nil)

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -189,6 +189,12 @@ module Dry
           to_a.each(&block)
         end
 
+        protected
+
+        def dirs
+          @dirs
+        end
+
         private
 
         # Converts a path string or pre-built component dir into a path and dir tuple

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -111,7 +111,6 @@ module Dry
         def add(path_or_dir)
           path, dir_to_add = path_and_dir(path_or_dir)
 
-          # TODO: is this worth even raising?
           raise ComponentDirAlreadyAddedError, path if dirs.key?(path)
 
           dirs[path] = dir_to_add.tap do |dir|

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -109,12 +109,12 @@ module Dry
         #
         # @see ComponentDir
         def add(path_or_dir)
-          path, dir = prepare_to_add(path_or_dir)
+          path, dir_to_add = prepare_to_add(path_or_dir)
 
           # TODO: is this worth even raising?
           raise ComponentDirAlreadyAddedError, path if dirs.key?(path)
 
-          dirs[path] = dir.tap do |dir|
+          dirs[path] = dir_to_add.tap do |dir|
             yield dir if block_given?
             apply_defaults_to_dir(dir)
           end

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -130,16 +130,6 @@ module Dry
           end
         end
 
-        # WIP
-        def add_dir(dir)
-          path = dir.path
-          raise ComponentDirAlreadyAddedError, path if dirs.key?(path)
-
-          dirs[path] = dir.tap do |dir|
-            apply_defaults_to_dir(dir)
-          end
-        end
-
         def dir(path)
           @dirs.fetch(path).tap do |dir|
             yield dir if block_given?

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -117,6 +117,16 @@ module Dry
           end
         end
 
+        # WIP
+        def add_dir(dir)
+          path = dir.path
+          raise ComponentDirAlreadyAddedError, path if dirs.key?(path)
+
+          dirs[path] = dir.tap do |dir|
+            apply_defaults_to_dir(dir)
+          end
+        end
+
         # Returns the added component dirs, with default settings applied
         #
         # @return [Hash<String, ComponentDir>] the component dirs as a hash, keyed by path

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -121,6 +121,8 @@ module Dry
         end
 
         def dir(path)
+          raise NoComponentDirError, path unless @dirs.key?(path)
+
           @dirs.fetch(path).tap do |dir|
             yield dir if block_given?
           end

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -218,7 +218,7 @@ module Dry
         # Returns the hash of component dirs, keyed by their paths
         #
         # Recently changed default configuration may not be applied to these dirs. Use
-        # #to_a or #each
+        # #to_a or #each to access dirs with default configuration fully applied.
         #
         # This method exists to encapsulate the instance variable and to serve the needs
         # of #initialize_copy

--- a/lib/dry/system/config/namespace.rb
+++ b/lib/dry/system/config/namespace.rb
@@ -21,7 +21,7 @@ module Dry
       #
       # @see Namespaces#add
       #
-      # @api private
+      # @api public
       class Namespace
         ROOT_PATH = nil
 

--- a/lib/dry/system/config/namespace.rb
+++ b/lib/dry/system/config/namespace.rb
@@ -27,10 +27,13 @@ module Dry
 
         include Dry::Equalizer(:path, :key, :const)
 
+        # @api public
         attr_reader :path
 
+        # @api public
         attr_reader :key
 
+        # @api public
         attr_reader :const
 
         # Returns a namespace configured to serve as the default root namespace for a
@@ -48,20 +51,24 @@ module Dry
           )
         end
 
+        # @api private
         def initialize(path:, key:, const:)
           @path = path
           @key = key
           @const = const
         end
 
+        # @api public
         def root?
           path == ROOT_PATH
         end
 
+        # @api public
         def path?
           !root?
         end
 
+        # @api private
         def default_key?
           key == path
         end

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -85,8 +85,8 @@ module Dry
         #
         # @param path [String] the path to the sub-directory of source files to which this
         #   namespace should apply, relative to the component dir
-        # @param identifier [String, nil] the leading namespace to apply to the registered
-        #   identifiers for the components. Set `nil` for the identifiers to be top-level.
+        # @param key [String, nil] the leading namespace to apply to the container keys
+        #   for the components. Set `nil` for the keys to be top-level.
         # @param const [String, nil] the Ruby constant namespace to expect for constants
         #   defined within the components. This should be provided in underscored string
         #   form, e.g. "hello_there/world" for a Ruby constant of `HelloThere::World`. Set
@@ -151,6 +151,8 @@ module Dry
         # Returns the count of configured namespaces
         #
         # @return [Integer]
+        #
+        # @api public
         def length
           namespaces.length
         end
@@ -167,9 +169,9 @@ module Dry
 
         # Returns the configured namespaces as an array
         #
-        # This adds a root namespace to the end of the array if one was not configured
-        # manually. This fallback ensures that all components in the component dir can be
-        # loaded.
+        # Adds a default root namespace to the end of the array if one was not added
+        # explicitly. This fallback ensures that all components in the component dir can
+        # be loaded.
         #
         # @return [Array<Namespace>] the namespaces
         #

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -138,6 +138,14 @@ module Dry
           namespaces.delete(Namespace::ROOT_PATH)
         end
 
+        # Returns the paths of the configured namespaces
+        #
+        # @return [Array<String,nil>] the namespace paths, with nil representing the root
+        #   namespace
+        def paths
+          namespaces.keys
+        end
+
         # Returns the count of configured namespaces
         #
         # @return [Integer]

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -26,6 +26,29 @@ module Dry
           @namespaces = source.namespaces.dup
         end
 
+        # Returns the namespace configured for the path, or nil if no such namespace has
+        # been configured
+        #
+        # @return [Namespace, nil] the namespace, if configured
+        #
+        # @api public
+        def namespace(path)
+          namespaces[path]
+        end
+
+        # @api public
+        alias_method :[], :namespace
+
+        # Returns the namespace configured for the root path, or nil if the root namespace
+        # has not been configured
+        #
+        # @return [Namespace, nil] the root namespace, if configured
+        #
+        # @api public
+        def root
+          namespaces[Namespace::ROOT_PATH]
+        end
+
         # rubocop:disable Layout/LineLength
 
         # Adds a component dir namespace
@@ -89,6 +112,30 @@ module Dry
         # @api public
         def add_root(key: nil, const: nil)
           add(Namespace::ROOT_PATH, key: key, const: const)
+        end
+
+        # Deletes the configured namespace for the given path and returns the namespace
+        #
+        # If no namespace was previously configured for the given path, returns nil
+        #
+        # @param path [String] the path for the namespace
+        #
+        # @return [Namespace, nil]
+        #
+        # @api public
+        def delete(path)
+          namespaces.delete(path)
+        end
+
+        # Deletes the configured root namespace and returns the namespace
+        #
+        # If no root namespace was previously configured, returns nil
+        #
+        # @return [Namespace, nil]
+        #
+        # @api public
+        def delete_root
+          namespaces.delete(Namespace::ROOT_PATH)
         end
 
         # @api private

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -87,7 +87,7 @@ module Dry
         # @see #add
         #
         # @api public
-        def root(key: nil, const: nil)
+        def add_root(key: nil, const: nil)
           add(Namespace::ROOT_PATH, key: key, const: const)
         end
 

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -138,7 +138,12 @@ module Dry
           namespaces.delete(Namespace::ROOT_PATH)
         end
 
-        # @api private
+        # Returns the count of configured namespaces
+        #
+        # @return [Integer]
+        def length
+          namespaces.length
+        end
         def empty?
           namespaces.empty?
         end

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/deprecations"
 require "dry/system/errors"
 require_relative "namespace"
 
@@ -43,7 +44,19 @@ module Dry
         # @return [Namespace, nil] the root namespace, if configured
         #
         # @api public
-        def root
+        def root(**options)
+          if options.any?
+            Dry::Core::Deprecations.announce(
+              "Dry::System::Config::Namespaces#root (with arguments)",
+              "Use `#add_root(key: nil, const: nil)` instead",
+              tag: "dry-system",
+              uplevel: 1
+            )
+
+            add_root(**options)
+            return
+          end
+
           namespaces[Namespace::ROOT_PATH]
         end
 

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -36,7 +36,7 @@ module Dry
           namespaces[path]
         end
 
-        # @api public
+        # (see #namespace)
         alias_method :[], :namespace
 
         # Returns the namespace configured for the root path, or nil if the root namespace
@@ -152,6 +152,12 @@ module Dry
         def length
           namespaces.length
         end
+
+        # Returns true if there are no configured namespaces
+        #
+        # @return [Boolean]
+        #
+        # @api public
         def empty?
           namespaces.empty?
         end

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -142,6 +142,8 @@ module Dry
         #
         # @return [Array<String,nil>] the namespace paths, with nil representing the root
         #   namespace
+        #
+        # @api public
         def paths
           namespaces.keys
         end
@@ -171,14 +173,14 @@ module Dry
         #
         # @return [Array<Namespace>] the namespaces
         #
-        # @api private
+        # @api public
         def to_a
           namespaces.values.tap do |arr|
             arr << Namespace.default_root unless arr.any?(&:root?)
           end
         end
 
-        # @api private
+        # @api public
         def each(&block)
           to_a.each(&block)
         end

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -135,7 +135,7 @@ module Dry
         #
         # @api public
         def delete_root
-          namespaces.delete(Namespace::ROOT_PATH)
+          delete(Namespace::ROOT_PATH)
         end
 
         # Returns the paths of the configured namespaces

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -35,8 +35,6 @@ module Dry
         def namespace(path)
           namespaces[path]
         end
-
-        # (see #namespace)
         alias_method :[], :namespace
 
         # Returns the namespace configured for the root path, or nil if the root namespace
@@ -182,6 +180,11 @@ module Dry
           end
         end
 
+        # Calls the given block once for each configured namespace, passing the namespace
+        # as an argument.
+        #
+        # @yieldparam namespace [Namespace] the yielded namespace
+        #
         # @api public
         def each(&block)
           to_a.each(&block)

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -152,6 +152,7 @@ module Dry
         def length
           namespaces.length
         end
+        alias_method :size, :length
 
         # Returns true if there are no configured namespaces
         #

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -11,12 +11,6 @@ module Dry
       end
     end
 
-    NoComponentDirError = Class.new(StandardError) do
-      def initialize(path)
-        super("No component dir configured with path '#{path}'")
-      end
-    end
-
     # Error raised when a namespace for a component dir is added to configuration more
     # than once
     NamespaceAlreadyAddedError = Class.new(StandardError) do

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -11,6 +11,12 @@ module Dry
       end
     end
 
+    NoComponentDirError = Class.new(StandardError) do
+      def initialize(path)
+        super("No component dir configured with path '#{path}'")
+      end
+    end
+
     # Error raised when a namespace for a component dir is added to configuration more
     # than once
     NamespaceAlreadyAddedError = Class.new(StandardError) do

--- a/spec/integration/container/auto_registration/component_dir_namespaces/autoloading_loader_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/autoloading_loader_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Component dir namespaces / Autoloading loader" do
   context "distinct constant namespace for root" do
     let(:component_dir_config) {
       -> dir {
-        dir.namespaces.root const: "my_namespace"
+        dir.namespaces.add_root const: "my_namespace"
       }
     }
 

--- a/spec/integration/container/auto_registration/component_dir_namespaces/default_loader_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/default_loader_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "Component dir namespaces / Default loader" do
     context "distinct constant namespace for root" do
       let(:component_dir_config) {
         -> dir {
-          dir.namespaces.root const: "my_namespace"
+          dir.namespaces.add_root const: "my_namespace"
         }
       }
 
@@ -245,7 +245,7 @@ RSpec.describe "Component dir namespaces / Default loader" do
     describe "distinct key namespace for root" do
       let(:component_dir_config) {
         -> dir {
-          dir.namespaces.root key: "my_ns"
+          dir.namespaces.add_root key: "my_ns"
         }
       }
 

--- a/spec/integration/container/auto_registration/component_dir_namespaces/multiple_namespaces_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/multiple_namespaces_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Component dir namespaces / Multiple namespaces" do
     context "leading root namespace before configured path namespace" do
       let(:component_dir_config) {
         -> dir {
-          dir.namespaces.root
+          dir.namespaces.add_root
           dir.namespaces.add "test", key: nil
         }
       }
@@ -237,7 +237,7 @@ RSpec.describe "Component dir namespaces / Multiple namespaces" do
     context "leading root namespace" do
       let(:component_dir_config) {
         -> dir {
-          dir.namespaces.root
+          dir.namespaces.add_root
           dir.namespaces.add "admin", key: nil
           dir.namespaces.add "test", key: nil
         }
@@ -270,7 +270,7 @@ RSpec.describe "Component dir namespaces / Multiple namespaces" do
       let(:component_dir_config) {
         -> dir {
           dir.namespaces.add "admin", key: nil
-          dir.namespaces.root
+          dir.namespaces.add_root
           dir.namespaces.add "test", key: nil
         }
       }

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Dry::System::Config::ComponentDirs do
     end
 
     it "adds a pre-built component dir" do
-      dir = Dry::System::Config::ComponentDir.new("test/path").tap do |dir|
-        dir.auto_register = false
-        dir.add_to_load_path = false
+      dir = Dry::System::Config::ComponentDir.new("test/path").tap do |d|
+        d.auto_register = false
+        d.add_to_load_path = false
       end
 
       expect { component_dirs.add(dir) }

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Dry::System::Config::ComponentDirs do
     end
 
     it "applies global default values configured before retrieval" do
-      dir = component_dirs.add("test/path")
+      component_dirs.add("test/path")
       component_dirs.namespaces.add "global_default"
       expect(component_dirs.dir("test/path").namespaces.paths).to eq ["global_default"]
     end
@@ -40,7 +40,7 @@ RSpec.describe Dry::System::Config::ComponentDirs do
     end
 
     it "applies global default values configured before retrieval" do
-      dir = component_dirs.add("test/path")
+      component_dirs.add("test/path")
       component_dirs.namespaces.add "global_default"
       expect(component_dirs["test/path"].namespaces.paths).to eq ["global_default"]
     end

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Dry::System::Config::ComponentDirs do
       component_dirs.memoize = true
 
       component_dirs.add "test/path" do |dir|
-        dir.namespaces.root # force the default value
+        dir.namespaces.add_root # force the default value
         dir.memoize = false
       end
 

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -118,4 +118,34 @@ RSpec.describe Dry::System::Config::ComponentDirs do
       expect(dir.memoize).to be false
     end
   end
+
+  describe "#delete" do
+    it "deletes and returns the component dir for the given path" do
+      added_dir = component_dirs.add("test/path")
+
+      deleted_dir = nil
+      expect { deleted_dir = component_dirs.delete("test/path") }
+        .to change { component_dirs.length }
+        .from(1).to(0)
+
+      expect(deleted_dir).to be added_dir
+    end
+
+    it "returns nil when no component dir has been added for the given path" do
+      expect(component_dirs.delete("test/path")).to be nil
+      expect(component_dirs.length).to eq 0
+    end
+  end
+
+  describe "#length" do
+    it "returns the count of component dirs" do
+      component_dirs.add "test/path_1"
+      component_dirs.add "test/path_2"
+      expect(component_dirs.length).to eq 2
+    end
+
+    it "returns 0 when there are no configured component dirs" do
+      expect(component_dirs.length).to eq 0
+    end
+  end
 end

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe Dry::System::Config::ComponentDirs do
         .to raise_error(Dry::System::ComponentDirAlreadyAddedError, %r{test/path})
     end
 
-
     it "applies default values configured before adding" do
       component_dirs.namespaces.add "global_default"
 

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -6,39 +6,101 @@ require "dry/system/config/component_dir"
 RSpec.describe Dry::System::Config::ComponentDirs do
   subject(:component_dirs) { described_class.new }
 
+  describe "#dir" do
+    it "returns the added dir for the given path" do
+      dir = component_dirs.add("test/path")
+      expect(component_dirs.dir("test/path")).to be dir
+    end
+
+    it "yields the dir" do
+      dir = component_dirs.add("test/path")
+      expect { |b| component_dirs.dir("test/path", &b) }.to yield_with_args dir
+    end
+
+    it "applies global default values configured before retrieval" do
+      dir = component_dirs.add("test/path")
+      component_dirs.namespaces.add "global_default"
+      expect(component_dirs.dir("test/path").namespaces.paths).to eq ["global_default"]
+    end
+
+    it "returns nil when no dir was added for the given path" do
+      expect(component_dirs.dir("test/path")).to be nil
+    end
+  end
+
+  describe "#[]" do
+    it "returns the added dir for the given path" do
+      dir = component_dirs.add("test/path")
+      expect(component_dirs["test/path"]).to be dir
+    end
+
+    it "yields the dir" do
+      dir = component_dirs.add("test/path")
+      expect { |b| component_dirs["test/path", &b] }.to yield_with_args dir
+    end
+
+    it "applies global default values configured before retrieval" do
+      dir = component_dirs.add("test/path")
+      component_dirs.namespaces.add "global_default"
+      expect(component_dirs["test/path"].namespaces.paths).to eq ["global_default"]
+    end
+
+    it "returns nil when no dir was added for the given path" do
+      expect(component_dirs["test/path"]).to be nil
+    end
+  end
+
   describe "#add" do
-    it "adds the component dir based on the provided configuration" do
+    it "adds a component dir by path, with config set on a yielded dir" do
       expect {
         component_dirs.add "test/path" do |dir|
           dir.auto_register = false
           dir.add_to_load_path = false
         end
       }
-        .to change { component_dirs.dirs.keys.length }
+        .to change { component_dirs.length }
         .from(0).to(1)
 
-      dir = component_dirs.dirs["test/path"]
+      dir = component_dirs["test/path"]
 
       expect(dir.path).to eq "test/path"
       expect(dir.auto_register).to eq false
       expect(dir.add_to_load_path).to eq false
     end
 
+    it "adds a pre-built component dir" do
+      dir = Dry::System::Config::ComponentDir.new("test/path").tap do |dir|
+        dir.auto_register = false
+        dir.add_to_load_path = false
+      end
+
+      expect { component_dirs.add(dir) }
+        .to change { component_dirs.length }
+        .from(0).to(1)
+
+      expect(component_dirs["test/path"]).to be dir
+    end
+
+    it "raises an error when a component dir has already been added for the given path" do
+      component_dirs.add "test/path"
+      expect { component_dirs.add "test/path" }.to raise_error(Dry::System::ComponentDirAlreadyAddedError, %r{test/path})
+    end
+
+    it "raises an error when a component dir has already been added for the given dir's path" do
+      component_dirs.add "test/path"
+      expect {
+        component_dirs.add Dry::System::Config::ComponentDir.new("test/path")
+      }
+        .to raise_error(Dry::System::ComponentDirAlreadyAddedError, %r{test/path})
+    end
+
+
     it "applies default values configured before adding" do
       component_dirs.namespaces.add "global_default"
 
       component_dirs.add "test/path"
 
-      dir = component_dirs.dirs["test/path"]
-      expect(dir.namespaces.to_a.map(&:path)).to eq ["global_default", nil]
-    end
-
-    it "applies default values configured after adding" do
-      component_dirs.add "test/path"
-
-      component_dirs.namespaces.add "global_default"
-
-      dir = component_dirs.dirs["test/path"]
+      dir = component_dirs["test/path"]
       expect(dir.namespaces.to_a.map(&:path)).to eq ["global_default", nil]
     end
 
@@ -51,20 +113,10 @@ RSpec.describe Dry::System::Config::ComponentDirs do
         dir.memoize = false
       end
 
-      dir = component_dirs.dirs["test/path"]
+      dir = component_dirs["test/path"]
 
       expect(dir.namespaces.to_a.map(&:path)).to eq [nil]
       expect(dir.memoize).to be false
-    end
-
-    context "component dir already added" do
-      before do
-        component_dirs.add "test/path"
-      end
-
-      it "raises an error" do
-        expect { component_dirs.add "test/path" }.to raise_error(Dry::System::ComponentDirAlreadyAddedError, %r{test/path})
-      end
     end
   end
 end

--- a/spec/unit/config/namespaces_spec.rb
+++ b/spec/unit/config/namespaces_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Dry::System::Config::Namespaces do
       expect {
         namespaces.add "test/path", key: "key_ns", const: "const_ns"
       }
-        .to change { namespaces.namespaces.keys.length }
+        .to change { namespaces.length }
         .from(0).to(1)
 
       ns = namespaces.namespaces["test/path"]
@@ -69,7 +69,7 @@ RSpec.describe Dry::System::Config::Namespaces do
       expect {
         namespaces.add_root key: "key_ns", const: "const_ns"
       }
-        .to change { namespaces.namespaces.keys.length }
+        .to change { namespaces.length }
         .from(0).to(1)
 
       ns = namespaces.namespaces[nil]
@@ -95,7 +95,7 @@ RSpec.describe Dry::System::Config::Namespaces do
       expect {
         deleted_namespace = namespaces.delete("test/path")
       }
-        .to change { namespaces.namespaces.keys.length }
+        .to change { namespaces.length }
         .from(1).to(0)
 
       expect(deleted_namespace).to be added_namespace
@@ -115,7 +115,7 @@ RSpec.describe Dry::System::Config::Namespaces do
       expect {
         deleted_namespace = namespaces.delete_root
       }
-        .to change { namespaces.namespaces.keys.length }
+        .to change { namespaces.length }
         .from(1).to(0)
 
       expect(deleted_namespace).to be added_namespace
@@ -124,6 +124,18 @@ RSpec.describe Dry::System::Config::Namespaces do
     it "returns nil when no root namespace has been configured" do
       expect(namespaces.delete_root).to be nil
       expect(namespaces).to be_empty
+    end
+  end
+
+  describe "#length" do
+    it "returns the count of configured namespaces" do
+      namespaces.add "test/path_1"
+      namespaces.add "test/path_2"
+      expect(namespaces.length).to eq 2
+    end
+
+    it "returns 0 when there are no configured namespaces" do
+      expect(namespaces.length).to eq 0
     end
   end
 

--- a/spec/unit/config/namespaces_spec.rb
+++ b/spec/unit/config/namespaces_spec.rb
@@ -6,6 +6,42 @@ require "dry/system/config/namespace"
 RSpec.describe Dry::System::Config::Namespaces do
   subject(:namespaces) { described_class.new }
 
+  describe "#namespace" do
+    it "returns the previously configured namespace for the given path" do
+      added_namespace = namespaces.add "test/path", key: "key_ns", const: "const_ns"
+
+      expect(namespaces.namespace("test/path")).to be added_namespace
+    end
+
+    it "returns nil when no namepace was previously configured for the given path" do
+      expect(namespaces.namespace("test/path")).to be nil
+    end
+  end
+
+  describe "#[]" do
+    it "returns the previously configured namespace for the given path" do
+      added_namespace = namespaces.add "test/path", key: "key_ns", const: "const_ns"
+
+      expect(namespaces["test/path"]).to be added_namespace
+    end
+
+    it "returns nil when no namepace was previously configured for the given path" do
+      expect(namespaces["test/path"]).to be nil
+    end
+  end
+
+  describe "#root" do
+    it "returns the previously configured root namespace" do
+      added_root_namespace = namespaces.add_root
+
+      expect(namespaces.root).to be added_root_namespace
+    end
+
+    it "returns nil when no root namespace was previously configured" do
+      expect(namespaces.root).to be nil
+    end
+  end
+
   describe "#add" do
     it "adds the namespace with the given configuration" do
       expect {
@@ -48,6 +84,46 @@ RSpec.describe Dry::System::Config::Namespaces do
       namespaces.add_root
 
       expect { namespaces.add_root }.to raise_error(Dry::System::NamespaceAlreadyAddedError, /root path/)
+    end
+  end
+
+  describe "#delete" do
+    it "deletes and returns the configured namespace for the given path" do
+      added_namespace = namespaces.add "test/path"
+
+      deleted_namespace = nil
+      expect {
+        deleted_namespace = namespaces.delete("test/path")
+      }
+        .to change { namespaces.namespaces.keys.length }
+        .from(1).to(0)
+
+      expect(deleted_namespace).to be added_namespace
+    end
+
+    it "returns nil when no namespace has been configured for the given path" do
+      expect(namespaces.delete("test/path")).to be nil
+      expect(namespaces).to be_empty
+    end
+  end
+
+  describe "#delete_root" do
+    it "deletes and returns the configured root namespace" do
+      added_namespace = namespaces.add_root
+
+      deleted_namespace = nil
+      expect {
+        deleted_namespace = namespaces.delete_root
+      }
+        .to change { namespaces.namespaces.keys.length }
+        .from(1).to(0)
+
+      expect(deleted_namespace).to be added_namespace
+    end
+
+    it "returns nil when no root namespace has been configured" do
+      expect(namespaces.delete_root).to be nil
+      expect(namespaces).to be_empty
     end
   end
 

--- a/spec/unit/config/namespaces_spec.rb
+++ b/spec/unit/config/namespaces_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Dry::System::Config::Namespaces do
     end
   end
 
-  describe "#root" do
+  describe "#add_root" do
     it "adds a root namespace with the given configuration" do
       expect {
-        namespaces.root key: "key_ns", const: "const_ns"
+        namespaces.add_root key: "key_ns", const: "const_ns"
       }
         .to change { namespaces.namespaces.keys.length }
         .from(0).to(1)
@@ -45,9 +45,9 @@ RSpec.describe Dry::System::Config::Namespaces do
     end
 
     it "raises an exception when a root namespace is already added" do
-      namespaces.root
+      namespaces.add_root
 
-      expect { namespaces.root }.to raise_error(Dry::System::NamespaceAlreadyAddedError, /root path/)
+      expect { namespaces.add_root }.to raise_error(Dry::System::NamespaceAlreadyAddedError, /root path/)
     end
   end
 
@@ -62,7 +62,7 @@ RSpec.describe Dry::System::Config::Namespaces do
   describe "#to_a" do
     it "returns an array of the configured namespaces, in order of definition" do
       namespaces.add "test/path", key: "test_key_ns"
-      namespaces.root key: "root_key_ns"
+      namespaces.add_root key: "root_key_ns"
 
       arr = namespaces.to_a
 
@@ -104,7 +104,7 @@ RSpec.describe Dry::System::Config::Namespaces do
   describe "#each" do
     it "yields each configured namespace" do
       namespaces.add "test/path", key: "test_key_ns"
-      namespaces.root key: "root_key_ns"
+      namespaces.add_root key: "root_key_ns"
 
       expect { |b|
         namespaces.each(&b)

--- a/spec/unit/config/namespaces_spec.rb
+++ b/spec/unit/config/namespaces_spec.rb
@@ -42,6 +42,39 @@ RSpec.describe Dry::System::Config::Namespaces do
     end
   end
 
+  describe "#root with argumments (DEPRECATED for #add_root)" do
+    before do
+      # We don't care about the deprecation messages when we're not testing for them
+      # specifically
+      Dry::Core::Deprecations.set_logger!(StringIO.new)
+    end
+
+    it "adds a root namespace with the given configuration" do
+      expect {
+        namespaces.root key: "key_ns", const: "const_ns"
+      }
+        .to change { namespaces.length }
+        .from(0).to(1)
+
+      ns = namespaces.namespaces[nil]
+
+      expect(ns).to be_root
+      expect(ns.path).to be_nil
+      expect(ns.key).to eq "key_ns"
+      expect(ns.const).to eq "const_ns"
+    end
+
+    it "prints a deprecation warning" do
+      logger = StringIO.new
+      Dry::Core::Deprecations.set_logger! logger
+
+      namespaces.root key: "key_ns", const: "const_ns"
+
+      logger.rewind
+      expect(logger.string).to match(/Namespaces#root \(with arguments\) is deprecated/)
+    end
+  end
+
   describe "#add" do
     it "adds the namespace with the given configuration" do
       expect {

--- a/spec/unit/config/namespaces_spec.rb
+++ b/spec/unit/config/namespaces_spec.rb
@@ -140,7 +140,11 @@ RSpec.describe Dry::System::Config::Namespaces do
   end
 
   describe "#empty?" do
-    it "returns true when a namespace has been added" do
+    it "returns true if there are no configured namespaces" do
+      expect(namespaces).to be_empty
+    end
+
+    it "returns false if a namespace has been added" do
       expect { namespaces.add "test/path" }
         .to change { namespaces.empty? }
         .from(true).to(false)


### PR DESCRIPTION
This PR broadens the interfaces of both the `Dry::System::Config::ComponentDirs` and `Dry::System::Config::Namespaces` collection classes to make them more useful to external consumers looking to programatically construct and inspect these configurations. Specifically, it supports the addition of `source_dirs` config to Hanami in https://github.com/hanami/hanami/pull/1133.

The updated API for `Config::ComponentDirs` includes:

- `#dir` (also aliased as `#[]`) has been added, for retrieving previously added dirs by their paths
- `#add` now accepts a single `path_or_dir` argument, supporting two distinct usages:
  - The existing usage, of providing a path string and then a block that is yielded a component dir object for that path, to be configured
  - A new usage, where a whole component dir object is already built and passed directly to `#add`
- `#delete` has been added, for deleting a previously added dir by its path
- `#length` has been added
- `#dirs` has been made protected, since it is the internal store for the dirs and may not always return dirs with the latest default values applied to them (`#to_a` and `#each` remain public and are preferred for this)

The updated API for `Config::Namespaces` includes:

- `#namespace` (also aliased as `#[]`) has been added, for retrieving previously added namespaces by their paths
- `#root` has been repurposed to returning a previously added root namespace (the previous usage is deprecated, but still supported for now)
- `#add_root` has been added, to take the place of the previous `#root` method, for adding a configured root namespace. This makes its purpose clearer and fits better alongside `#add`.
- `#delete` has been added, for deleting a previously added namespace by its path
- `#delete_root` has also been added, for deleting a previously added root namespace
- `#paths` has been added, returning an array of paths for the namespaces
- `#length` has been added

Along with this, API documentation has been lightly updated to make it clearer that these two collection config classes (along with their counterpart singular `Config::ComponentDir` and `Config::Namespace` classes) are public API.

I intend to make a new minor release of dry-system after this has merged, to allow the upcoming Hanami alpha to depend on it.

I'll also be squashing the commits in this PR when merging.