### PR TITLE
Allow bootsnap for Rubies up to 3.0.x

### DIFF
--- a/lib/dry/system/plugins/bootsnap.rb
+++ b/lib/dry/system/plugins/bootsnap.rb
@@ -36,7 +36,7 @@ module Dry
 
         # @api private
         def bootsnap_available?
-          RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.3.0" && RUBY_VERSION < "2.5.0"
+          RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.3.0" && RUBY_VERSION < "3.1.0"
         end
       end
     end


### PR DESCRIPTION
As per https://github.com/Shopify/bootsnap/commit/acefed8db9569b211d664f4165e277e1b26300aa, bootsnap is supported in all versions of Ruby >= 2.3, including head.