### PR TITLE
Stop delegating methods to container in boot DSL

### DIFF
--- a/lib/dry/system/lifecycle.rb
+++ b/lib/dry/system/lifecycle.rb
@@ -109,7 +109,6 @@ module Dry
 
       private
 
-      # @api private
       def trigger!(name, &block)
         if triggers.key?(name)
           triggers[name].(target)
@@ -118,17 +117,16 @@ module Dry
         end
       end
 
-      # @api private
-      def method_missing(meth, *args, &block)
-        if target.registered?(meth)
-          target[meth]
-        elsif container.key?(meth)
-          container[meth]
-        elsif ::Kernel.respond_to?(meth)
-          ::Kernel.public_send(meth, *args, &block)
+      def method_missing(name, *args, &block)
+        if ::Kernel.respond_to?(name)
+          ::Kernel.public_send(name, *args, &block)
         else
           super
         end
+      end
+
+      def respond_to_missing?(name, include_all = false)
+        ::Kernel.respond_to?(name, include_all) || super
       end
     end
   end

--- a/spec/fixtures/external_components/components/mailer.rb
+++ b/spec/fixtures/external_components/components/mailer.rb
@@ -2,7 +2,7 @@
 
 require "dry/system"
 
-Dry::System.register_component(:mailer, provider: :external_components) do
+Dry::System.register_component(:mailer, provider: :external_components) do |container|
   init do
     module ExternalComponents
       class Mailer
@@ -18,6 +18,6 @@ Dry::System.register_component(:mailer, provider: :external_components) do
   start do
     use :client
 
-    register(:mailer, ExternalComponents::Mailer.new(client))
+    register(:mailer, ExternalComponents::Mailer.new(container["client"]))
   end
 end

--- a/spec/fixtures/external_components/components/notifier.rb
+++ b/spec/fixtures/external_components/components/notifier.rb
@@ -2,7 +2,7 @@
 
 require "dry/system"
 
-Dry::System.register_component(:notifier, provider: :external_components) do
+Dry::System.register_component(:notifier, provider: :external_components) do |container|
   init do
     module ExternalComponents
       class Notifier
@@ -16,6 +16,6 @@ Dry::System.register_component(:notifier, provider: :external_components) do
   end
 
   start do
-    register(:notifier, ExternalComponents::Notifier.new(monitor))
+    register(:notifier, ExternalComponents::Notifier.new(container["monitor"]))
   end
 end

--- a/spec/fixtures/test/system/boot/client.rb
+++ b/spec/fixtures/test/system/boot/client.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-Test::Container.boot(:client) do
+Test::Container.boot(:client) do |container|
   use :logger
 
   Client = Struct.new(:logger)
 
-  register(:client, Client.new(logger))
+  register(:client, Client.new(container["logger"]))
 end

--- a/spec/unit/container/boot_spec.rb
+++ b/spec/unit/container/boot_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Dry::System::Container, ".boot" do
         end
 
         boot(:db) do
-          register(:db, Test::DB)
+          db = Test::DB
+          register(:db, db)
 
           init do
             db.establish_connection
@@ -33,7 +34,8 @@ RSpec.describe Dry::System::Container, ".boot" do
         end
 
         boot(:client) do
-          register(:client, Test::Client)
+          client = Test::Client
+          register(:client, client)
 
           init do
             client.establish_connection


### PR DESCRIPTION
There's too much magic in this behavior, and any concision it may add doesn't outweigh just how much harder it makes it to understand the behavior within these lifecycle blocks.

Fixes #164