### PR TITLE
Remove dry-configurable `setting` overload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem "dry-monitor"
 gem "dry-types"
 gem "zeitwerk"
 
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "allow-access-to-class-level-config-between-setting-definitions"
+
 group :tools do
   gem "pry-byebug", platforms: :mri
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem "dry-monitor"
 gem "dry-types"
 gem "zeitwerk"
 
-gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "allow-access-to-class-level-config-between-setting-definitions"
-
 group :tools do
   gem "pry-byebug", platforms: :mri
 end

--- a/dry-system.gemspec
+++ b/dry-system.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # to update dependencies edit project.yml
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "dry-auto_inject", ">= 0.4.0"
-  spec.add_runtime_dependency "dry-configurable", "~> 0.13", ">= 0.13.0"
+  spec.add_runtime_dependency "dry-configurable", "~> 0.14", ">= 0.14.0"
   spec.add_runtime_dependency "dry-container", "~> 0.9", ">= 0.9.0"
   spec.add_runtime_dependency "dry-core", "~> 0.5", ">= 0.5"
   spec.add_runtime_dependency "dry-inflector", "~> 0.1", ">= 0.1.2"

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -100,18 +100,6 @@ module Dry
 
         extend Dry::Core::Deprecations["Dry::System::Container"]
 
-        # Define a new configuration setting
-        #
-        # @see https://dry-rb.org/gems/dry-configurable
-        #
-        # @api public
-        def setting(name, default = Dry::Core::Constants::Undefined, **options, &block)
-          super(name, default, **options, &block)
-          # TODO: dry-configurable needs a public API for this
-          config._settings << _settings[name]
-          self
-        end
-
         # Configures the container
         #
         # @example

--- a/project.yml
+++ b/project.yml
@@ -11,7 +11,7 @@ gemspec:
   runtime_dependencies:
     - [concurrent-ruby, "~> 1.0"]
     - [dry-auto_inject, ">= 0.4.0"]
-    - [dry-configurable, "~> 0.13", ">= 0.13.0"]
+    - [dry-configurable, "~> 0.14", ">= 0.14.0"]
     - [dry-container, "~> 0.9", ">= 0.9.0"]
     - [dry-core, "~> 0.5", ">= 0.5"]
     - [dry-inflector, "~> 0.1", ">= 0.1.2"]


### PR DESCRIPTION
This is no longer needed given the change in dry-configurable at https://github.com/dry-rb/dry-configurable/pull/130.