### PR TITLE
Expect key namespace separator to be "." at all times

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -20,7 +20,6 @@ module Dry
       include Dry::Equalizer(:identifier, :namespace, :options)
 
       DEFAULT_OPTIONS = {
-        separator: DEFAULT_SEPARATOR,
         inflector: Dry::Inflector.new,
         loader: Loader
       }.freeze
@@ -137,7 +136,7 @@ module Dry
       #
       # @api public
       def const_path
-        namespace_const_path = namespace.const&.gsub(identifier.separator, PATH_SEPARATOR)
+        namespace_const_path = namespace.const&.gsub(KEY_SEPARATOR, PATH_SEPARATOR)
 
         if namespace_const_path
           "#{namespace_const_path}#{PATH_SEPARATOR}#{path_in_namespace}"

--- a/lib/dry/system/config/namespace.rb
+++ b/lib/dry/system/config/namespace.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/core/equalizer"
+require "dry/system/constants"
 
 module Dry
   module System
@@ -54,7 +55,9 @@ module Dry
         # @api private
         def initialize(path:, key:, const:)
           @path = path
-          @key = key
+          # Default keys (i.e. when the user does not explicitly provide one) for non-root
+          # paths will include path separators, which we must convert into key separators
+          @key = key && key == path ? key.gsub(PATH_SEPARATOR, KEY_SEPARATOR) : key
           @const = const
         end
 
@@ -66,11 +69,6 @@ module Dry
         # @api public
         def path?
           !root?
-        end
-
-        # @api private
-        def default_key?
-          key == path
         end
       end
     end

--- a/lib/dry/system/constants.rb
+++ b/lib/dry/system/constants.rb
@@ -9,7 +9,7 @@ module Dry
     RB_EXT = ".rb"
     RB_GLOB = "*.rb"
     PATH_SEPARATOR = File::SEPARATOR
-    DEFAULT_SEPARATOR = "."
+    KEY_SEPARATOR = "."
     WORD_REGEX = /\w+/.freeze
   end
 end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -89,6 +89,10 @@ module Dry
       setting :provider_registrar, default: Dry::System::ProviderRegistrar
       setting :importer, default: Dry::System::Importer
 
+      # We presume "." as key namespace separator. This is not intended to be
+      # user-configurable.
+      config.namespace_separator = KEY_SEPARATOR
+
       class << self
         def strategies(value = nil)
           if value
@@ -664,7 +668,7 @@ module Dry
             if (component = dir.component_for_key(key))
               break component
             end
-          } || IndirectComponent.new(Identifier.new(key, separator: config.namespace_separator))
+          } || IndirectComponent.new(Identifier.new(key))
         end
 
         def provider_from_source(name, source:, group:, namespace:, &block)

--- a/lib/dry/system/identifier.rb
+++ b/lib/dry/system/identifier.rb
@@ -13,20 +13,15 @@ module Dry
     #
     # @api public
     class Identifier
-      include Dry::Equalizer(:key, :separator)
+      include Dry::Equalizer(:key)
 
       # @return [String] the identifier's string key
       # @api public
       attr_reader :key
 
-      # @return [String] the configured namespace separator
-      # @api public
-      attr_reader :separator
-
       # @api private
-      def initialize(key, separator: DEFAULT_SEPARATOR)
+      def initialize(key)
         @key = key.to_s
-        @separator = separator
       end
 
       # @!method to_s
@@ -68,7 +63,7 @@ module Dry
       # @api public
       def start_with?(leading_namespaces)
         leading_namespaces.nil? ||
-          key.start_with?("#{leading_namespaces}#{separator}") ||
+          key.start_with?("#{leading_namespaces}#{KEY_SEPARATOR}") ||
           key.eql?(leading_namespaces)
       end
 
@@ -108,27 +103,27 @@ module Dry
       def namespaced(from:, to:)
         return self if from == to
 
-        separated_to = "#{to}#{separator}" if to
+        separated_to = "#{to}#{KEY_SEPARATOR}" if to
 
         new_key =
           if from.nil?
             "#{separated_to}#{key}"
           else
             key.sub(
-              /^#{Regexp.escape(from.to_s)}#{Regexp.escape(separator)}/,
+              /^#{Regexp.escape(from.to_s)}#{Regexp.escape(KEY_SEPARATOR)}/,
               separated_to || EMPTY_STRING
             )
           end
 
         return self if new_key == key
 
-        self.class.new(new_key, separator: separator)
+        self.class.new(new_key)
       end
 
       private
 
       def segments
-        @segments ||= key.split(separator)
+        @segments ||= key.split(KEY_SEPARATOR)
       end
     end
   end

--- a/lib/dry/system/importer.rb
+++ b/lib/dry/system/importer.rb
@@ -13,14 +13,11 @@ module Dry
     class Importer
       attr_reader :container
 
-      attr_reader :separator
-
       attr_reader :registry
 
       # @api private
       def initialize(container)
         @container = container
-        @separator = container.config.namespace_separator
         @registry = {}
       end
 

--- a/spec/integration/container/auto_registration/component_dir_namespaces/deep_namespace_paths_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/deep_namespace_paths_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Component dir namespaces / Deep namespace paths" do
     end
 
     context "lazy loading" do
-      it "registers components using the container's configured namespace_separator, not the path separator used for the namespace path" do
+      it "registers components using the key namespace separator ('.'), not the path separator used for the namespace path" do
         expect(container["ns.nested.component"]).to be_an_instance_of Component
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe "Component dir namespaces / Deep namespace paths" do
         container.finalize!
       end
 
-      it "registers components using the container's configured namespace_separator, not the path separator used for the namespace path" do
+      it "registers components using the key namespace separator ('.'), not the path separator used for the namespace path" do
         expect(container["ns.nested.component"]).to be_an_instance_of Component
       end
     end

--- a/spec/unit/identifier_spec.rb
+++ b/spec/unit/identifier_spec.rb
@@ -3,10 +3,9 @@
 require "dry/system/identifier"
 
 RSpec.describe Dry::System::Identifier do
-  subject(:identifier) { described_class.new(key, separator: separator) }
+  subject(:identifier) { described_class.new(key) }
 
   let(:key) { "kittens.operations.belly_rub" }
-  let(:separator) { "." }
 
   describe "#key" do
     it "returns the identifier's key" do
@@ -53,23 +52,6 @@ RSpec.describe Dry::System::Identifier do
 
     it "returns true when the provided string matches all segments of the identifier string" do
       expect(identifier.start_with?("kittens.operations.belly_rub")).to be true
-    end
-
-    describe "alternative separators" do
-      let(:key) { "kittens->operations->belly_rub" }
-      let(:separator) { "->" }
-
-      it "returns true when the given string matches the base segment of the key" do
-        expect(identifier.start_with?("kittens")).to be true
-      end
-
-      it "returns true when the given string matches multiple base segments of the key" do
-        expect(identifier.start_with?("kittens->operations")).to be true
-      end
-
-      it "returns false when a non-matching separator is given" do
-        expect(identifier.start_with?("kittens/operations")).to be false
-      end
     end
 
     it "returns true when the provided string is nil" do
@@ -132,10 +114,6 @@ RSpec.describe Dry::System::Identifier do
       it "adds the namespace" do
         expect(new_identifier.key).to eq "cats.kittens.operations.belly_rub"
       end
-    end
-
-    it "preserves other attributes" do
-      expect(new_identifier.separator).to eq identifier.separator
     end
 
     it "returns itself if the key is unchanged" do


### PR DESCRIPTION
Understanding "." as a key namespace separator is important to understanding dry-system behavior in general, and it is presumed across all our docs and other related material.

It does not make sense for our usage of dry-container for this to be configurable.

Resolves #192.