### PR TITLE
Tidy the dependency graph plugin

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -94,14 +94,6 @@ module Dry
       config.namespace_separator = KEY_SEPARATOR
 
       class << self
-        def strategies(value = nil)
-          if value
-            @strategies = value
-          else
-            @strategies ||= Dry::AutoInject::Strategies
-          end
-        end
-
         extend Dry::Core::Deprecations["Dry::System::Container"]
 
         # @!method config
@@ -499,8 +491,8 @@ module Dry
         # @param options [Hash] injector options
         #
         # @api public
-        def injector(options = {strategies: strategies})
-          Dry::AutoInject(self, options)
+        def injector(**options)
+          Dry::AutoInject(self, **options)
         end
 
         # Requires one or more files relative to the container's root

--- a/lib/dry/system/plugins/dependency_graph.rb
+++ b/lib/dry/system/plugins/dependency_graph.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "dry/system/constants"
-require "dry/system/plugins/dependency_graph/strategies"
+require_relative "dependency_graph/strategies"
 
 module Dry
   module System
@@ -12,34 +11,43 @@ module Dry
         def self.extended(system)
           super
 
-          system.use(:notifications)
+          system.instance_eval do
+            use(:notifications)
 
-          system.setting :ignored_dependencies, default: []
+            setting :dependency_graph do
+              setting :ignored_dependencies, default: []
+            end
 
-          system.after(:configure) do
-            self[:notifications].register_event(:resolved_dependency)
-            self[:notifications].register_event(:registered_dependency)
-
-            strategies(Strategies)
+            after(:configure) do
+              self[:notifications].register_event(:resolved_dependency)
+              self[:notifications].register_event(:registered_dependency)
+            end
           end
         end
 
         # @api private
         def self.dependencies
-          {'dry-events': "dry/events/publisher"}
+          {"dry-events" => "dry/events/publisher"}
+        end
+
+        # @api private
+        def injector(**options)
+          super(**options.merge(strategies: DependencyGraph::Strategies))
         end
 
         # @api private
         def register(key, contents = nil, options = {}, &block)
-          super
-          dependency_key = key.to_s
-          unless config.ignored_dependencies.include?(dependency_key)
-            self[:notifications].instrument(
-              :registered_dependency, key: dependency_key, class: self[dependency_key].class
-            )
-          end
+          super.tap do
+            key = key.to_s
 
-          self
+            unless config.dependency_graph.ignored_dependencies.include?(key)
+              self[:notifications].instrument(
+                :registered_dependency,
+                key: key,
+                class: self[key].class
+              )
+            end
+          end
         end
       end
     end

--- a/spec/integration/container/plugins/dependency_graph_spec.rb
+++ b/spec/integration/container/plugins/dependency_graph_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Plugins / Dependency Graph" do
         configure do |config|
           config.root = SPEC_ROOT.join("fixtures/app").realpath
           config.component_dirs.add "lib"
-          config.ignored_dependencies = ["ignored_spec_service"]
+          config.dependency_graph.ignored_dependencies = ["ignored_spec_service"]
         end
 
         register_provider(:mailer, from: :external_components)


### PR DESCRIPTION
This makes some changes to make the dependency graph plugin less intrusive on the overall container behaviour. It:

- Nests its setting underneath a top-level `dependency_graph` setting
- Removes the ambiguously named and potentially buggy (due to its ivars that may end up being set after the cotnainer is frozen) `Container.strategies` method and instead provides its custom auto-injector strategies via an overload of the container's public `.injector` method options.