### PR TITLE
Remove `use` method from provider source

### DIFF
--- a/lib/dry/system/provider/source.rb
+++ b/lib/dry/system/provider/source.rb
@@ -183,24 +183,6 @@ module Dry
         # @api public
         def stop; end
 
-        # Starts the other providers registered with the given names.
-        #
-        # Calling this method is helpful if your provider's source behavior depends on the
-        # results of other providers.
-        #
-        # @param provider_names [Array<Symbol>] Names of the other providers to start
-        #
-        # @return [self]
-        #
-        # @api public
-        def use(*provider_names)
-          provider_names.each do |name|
-            target_container.start(name)
-          end
-
-          self
-        end
-
         # Registers a "before" callback for the given lifecycle step.
         #
         # The given block will be run before the lifecycle step method is run. The block

--- a/spec/fixtures/external_components/components/mailer.rb
+++ b/spec/fixtures/external_components/components/mailer.rb
@@ -16,7 +16,7 @@ Dry::System.register_provider_source(:mailer, group: :external_components) do
   end
 
   start do
-    use :client
+    target.start :client
 
     register(:mailer, ExternalComponents::Mailer.new(target_container["client"]))
   end

--- a/spec/fixtures/test/system/providers/client.rb
+++ b/spec/fixtures/test/system/providers/client.rb
@@ -2,7 +2,7 @@
 
 Test::Container.register_provider(:client) do
   start do
-    use :logger
+    target.start :logger
 
     Test::Client = Struct.new(:logger)
 


### PR DESCRIPTION
This can be (and has been) confused for activating plugins, which use the `use` method on the container, and given we now have consistent and easy-to-understand access to the target container via `target`, it's more straightforward to use `target.start :some_provider` instead of a provider source-specifiic method like `#use`.

In addition, this is more flexible, since you can also access the other lifecycle steps for providers now too, like `target.prepare :some_provider`.