### PR TITLE
Support all injector strategies for dependency graph plugin

### DIFF
--- a/lib/dry/system/plugins/dependency_graph/strategies.rb
+++ b/lib/dry/system/plugins/dependency_graph/strategies.rb
@@ -15,13 +15,49 @@ module Dry
             # @api private
             def define_initialize(klass)
               @container["notifications"].instrument(
-                :resolved_dependency, dependency_map: dependency_map.to_h, target_class: klass
+                :resolved_dependency,
+                dependency_map: dependency_map.to_h,
+                target_class: klass
               )
+
+              super(klass)
+            end
+          end
+
+          # @api private
+          class Args < Dry::AutoInject::Strategies::Args
+            private
+
+            # @api private
+            def define_initialize(klass)
+              @container["notifications"].instrument(
+                :resolved_dependency,
+                dependency_map: dependency_map.to_h,
+                target_class: klass
+              )
+
+              super(klass)
+            end
+          end
+
+          class Hash < Dry::AutoInject::Strategies::Hash
+            private
+
+            # @api private
+            def define_initialize(klass)
+              @container["notifications"].instrument(
+                :resolved_dependency,
+                dependency_map: dependency_map.to_h,
+                target_class: klass
+              )
+
               super(klass)
             end
           end
 
           register :kwargs, Kwargs
+          register :args, Args
+          register :hash, Hash
           register :default, Kwargs
         end
       end


### PR DESCRIPTION
This carries on from the work in #139 (thanks @davydovanton!) and expands upon the test suite to cover all injector strategies.

Closes #139.