### PR TITLE
Restore support for configurable instance proc

### DIFF
--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -60,7 +60,7 @@ module Dry
       # @return [Object] component's class instance
       # @api public
       def instance(*args)
-        loader.call(self, *args)
+        options[:instance]&.call(self, *args) || loader.call(self, *args)
       end
       ruby2_keywords(:instance) if respond_to?(:ruby2_keywords, true)
 

--- a/lib/dry/system/component_dir.rb
+++ b/lib/dry/system/component_dir.rb
@@ -148,6 +148,7 @@ module Dry
         {
           auto_register: auto_register,
           loader: loader,
+          instance: instance,
           memoize: memoize
         }
       end

--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -20,7 +20,7 @@ module Dry
         #   Sets the auto-registration policy for the component dir.
         #
         #   This may be a simple boolean to enable or disable auto-registration for all
-        #   components, or a proc accepting a `Dry::Sytem::Component` and returning a
+        #   components, or a proc accepting a {Dry::System::Component} and returning a
         #   boolean to configure auto-registration on a per-component basis
         #
         #   Defaults to `true`.
@@ -50,30 +50,48 @@ module Dry
         #   @api public
         setting :auto_register, default: true
 
-        # @!method add_to_load_path=(policy)
+        # @!method instance=(instance_proc)
         #
-        #   Sets whether the dir should be added to the `$LOAD_PATH` after the container
-        #   is configured.
+        #   Sets a proc used to return the instance of any component within the component
+        #   dir.
         #
-        #   Defaults to `true`. This may need to be set to `false` when using a class
-        #   autoloading system.
+        #   This proc should accept a {Dry::System::Component} and return the object to
+        #   serve as the component's instance.
         #
-        #   @param policy [Boolean]
-        #   @return [Boolean]
+        #   When you provide an instance proc, it will be used in preference to the
+        #   {loader} (either the default loader or an explicitly configured one). Provide
+        #   an instance proc when you want a simple way to customize the instance for
+        #   certain components. For complete control, provide a replacement loader via
+        #   {loader=}.
         #
-        #   @see add_to_load_path
-        #   @see Container.configure
+        #   Defaults to `nil`.
+        #
+        #   @param instance_proc [Proc, nil]
+        #   @return [Proc]
+        #
+        #   @example
+        #     dir.instance = proc do |component|
+        #       if component.key.match?(/workers\./)
+        #         # Register classes for jobs
+        #         component.loader.constant(component)
+        #       else
+        #         # Otherwise register regular instances per default loader
+        #         component.loader.call(component)
+        #       end
+        #     end
+        #
+        #   @see Component, Loader
         #   @api public
         #
-        # @!method add_to_load_path
+        # @!method instance
         #
-        #   Returns the configured value.
+        #   Returns the configured instance proc.
         #
-        #   @return [Boolean]
+        #   @return [Proc, nil]
         #
-        #   @see add_to_load_path=
+        #   @see instance=
         #   @api public
-        setting :add_to_load_path, default: true
+        setting :instance
 
         # @!method loader=(loader)
         #
@@ -82,7 +100,8 @@ module Dry
         #
         #   Defaults to `Dry::System::Loader`.
         #
-        #   When using a class autoloader, consider using `Dry::System::Loader::Autoloading`
+        #   When using an autoloader like Zeitwerk, consider using
+        #   `Dry::System::Loader::Autoloading`
         #
         #   @param loader [#call] the loader
         #   @return [#call] the configured loader
@@ -149,6 +168,31 @@ module Dry
         #   @see Namespaces#add
         #   @api public
         setting :namespaces, default: Namespaces.new, cloneable: true
+
+        # @!method add_to_load_path=(policy)
+        #
+        #   Sets whether the dir should be added to the `$LOAD_PATH` after the container
+        #   is configured.
+        #
+        #   Defaults to `true`. This may need to be set to `false` when using a class
+        #   autoloading system.
+        #
+        #   @param policy [Boolean]
+        #   @return [Boolean]
+        #
+        #   @see add_to_load_path
+        #   @see Container.configure
+        #   @api public
+        #
+        # @!method add_to_load_path
+        #
+        #   Returns the configured value.
+        #
+        #   @return [Boolean]
+        #
+        #   @see add_to_load_path=
+        #   @api public
+        setting :add_to_load_path, default: true
 
         # @api public
         def default_namespace=(namespace)

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -17,7 +17,7 @@ module Dry
         #
         #   Sets a default `auto_register` for all added component dirs
         #
-        #   @see ComponentDir.auto_register
+        #   @see ComponentDir.auto_register=
         #   @see auto_register
         #
         # @!method auto_register
@@ -26,24 +26,24 @@ module Dry
         #
         #   @see auto_register=
 
-        # @!method add_to_load_path=(value)
+        # @!method instance=(value)
         #
-        #   Sets a default `add_to_load_path` value for all added component dirs
+        #   Sets a default `instance` for all added component dirs
         #
-        #   @see ComponentDir.add_to_load_path
-        #   @see add_to_load_path
+        #   @see ComponentDir.instance=
+        #   @see auto_register
         #
-        # @!method add_to_load_path
+        # @!method auto_register
         #
-        #   Returns the configured default `add_to_load_path`
+        #   Returns the configured default `instance`
         #
-        #   @see add_to_load_path=
+        #   @see instance=
 
         # @!method loader=(value)
         #
         #   Sets a default `loader` value for all added component dirs
         #
-        #   @see ComponentDir.loader
+        #   @see ComponentDir.loader=
         #   @see loader
         #
         # @!method loader
@@ -56,7 +56,7 @@ module Dry
         #
         #   Sets a default `memoize` value for all added component dirs
         #
-        #   @see ComponentDir.memoize
+        #   @see ComponentDir.memoize=
         #   @see memoize
         #
         # @!method memoize
@@ -76,6 +76,19 @@ module Dry
         #   @see Dry::System::Config::Namespaces#add
         #
         #   @return [Namespaces] the namespaces
+
+        # @!method add_to_load_path=(value)
+        #
+        #   Sets a default `add_to_load_path` value for all added component dirs
+        #
+        #   @see ComponentDir.add_to_load_path=
+        #   @see add_to_load_path
+        #
+        # @!method add_to_load_path
+        #
+        #   Returns the configured default `add_to_load_path`
+        #
+        #   @see add_to_load_path=
 
         # rubocop:enable Layout/LineLength
 

--- a/spec/integration/container/auto_registration/custom_instance_proc_spec.rb
+++ b/spec/integration/container/auto_registration/custom_instance_proc_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe "Auto-registration / Custom instance proc" do
+  before :context do
+    with_directory(@dir = make_tmp_directory) do
+      write "lib/foo.rb", <<~RUBY
+        module Test
+          class Foo; end
+        end
+      RUBY
+    end
+  end
+
+  let(:container) {
+    root = @dir
+    Class.new(Dry::System::Container) {
+      configure do |config|
+        config.root = root
+
+        config.component_dirs.add "lib" do |dir|
+          dir.namespaces.add_root const: "test"
+          dir.instance = proc do |component, *args|
+            # Return the component's string key as its instance
+            component.key
+          end
+        end
+      end
+    }
+  }
+
+  shared_examples "custom instance proc" do
+    it "registers the component using the custom loader" do
+      expect(container["foo"]).to eq "foo"
+    end
+  end
+
+  context "Non-finalized container" do
+    include_examples "custom instance proc"
+  end
+
+  context "Finalized container" do
+    before do
+      container.finalize!
+    end
+
+    include_examples "custom instance proc"
+  end
+end


### PR DESCRIPTION
Adds a configurable `instance` proc on all component dirs, which was previously available only on the configuration object yielded to block given to `Container.auto_register!`, removed in 0.19.0 to make way for consistently behaving and configurable component dirs.

Now users have two ways to customise component instantiation: the `instance` proc for simple cases, or a full replacement `loader` for more advanced cases.

Fixes #180.