### PR TITLE
Conditional providers

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -290,7 +290,7 @@ module Dry
         # @return [self]
         #
         # @api public
-        def register_provider(name, namespace: nil, from: nil, source: nil, &block)
+        def register_provider(name, namespace: nil, from: nil, source: nil, if: true, &block)
           raise ProviderAlreadyRegisteredError, name if providers.key?(name)
 
           if from && source.is_a?(Class)
@@ -300,6 +300,9 @@ module Dry
           if block && source.is_a?(Class)
             raise ArgumentError, "You must supply only a `source:` option or a block, not both"
           end
+
+          provider_if = binding.local_variable_get(:if)
+          return self unless provider_if
 
           provider =
             if from
@@ -315,6 +318,8 @@ module Dry
             end
 
           providers.register_provider provider
+
+          self
         end
         # rubocop:enable Metrics/PerceivedComplexity
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -217,80 +217,101 @@ module Dry
           self
         end
 
-        # Registers a provider and its lifecycle hooks
+        # rubocop:disable Layout/LineLength
+
+        # @overload register_provider(name, namespace: nil, from: nil, source: nil, if: true, &block)
+        #   Registers a provider and its lifecycle hooks
         #
-        # By convention, you should place a file for each provider in one of the
-        # configured `provider_dirs`, and they will be loaded on demand when components
-        # are loaded in isolation, or during container finalization.
+        #   By convention, you should place a file for each provider in one of the
+        #   configured `provider_dirs`, and they will be loaded on demand when components
+        #   are loaded in isolation, or during container finalization.
         #
-        # @example
-        #   # system/container.rb
-        #   class MyApp < Dry::System::Container
-        #     configure do |config|
-        #       config.root = Pathname("/path/to/app")
+        #   @example
+        #     # system/container.rb
+        #     class MyApp < Dry::System::Container
+        #       configure do |config|
+        #         config.root = Pathname("/path/to/app")
+        #       end
         #     end
         #
-        #   # system/providers/db.rb
-        #   #
-        #   # Simple provider registration
-        #   MyApp.register_provider(:db) do
-        #     require "db"
-        #     register("db", DB.new)
-        #   end
-        #
-        #   # system/providers/db.rb
-        #   #
-        #   # Provider registration with lifecycle triggers
-        #   MyApp.register_provider(:db) do |container|
-        #     init do
-        #       require "db"
-        #       DB.configure(ENV["DB_URL"])
-        #       container.register("db", DB.new)
+        #     # system/providers/db.rb
+        #     #
+        #     # Simple provider registration
+        #     MyApp.register_provider(:db) do
+        #       start do
+        #         require "db"
+        #         register("db", DB.new)
+        #       end
         #     end
         #
-        #     start do
-        #       container["db"].establish_connection
+        #     # system/providers/db.rb
+        #     #
+        #     # Provider registration with lifecycle triggers
+        #     MyApp.register_provider(:db) do |container|
+        #       init do
+        #         require "db"
+        #         DB.configure(ENV["DB_URL"])
+        #         container.register("db", DB.new)
+        #       end
+        #
+        #       start do
+        #         container["db"].establish_connection
+        #       end
+        #
+        #       stop do
+        #         container["db"].close_connection
+        #       end
         #     end
         #
-        #     stop do
-        #       container["db"].close_connection
+        #     # system/providers/db.rb
+        #     #
+        #     # Provider registration which uses another provider
+        #     MyApp.register_provider(:db) do |container|
+        #       start do
+        #         use :logger
+        #
+        #         require "db"
+        #         DB.configure(ENV['DB_URL'], logger: logger)
+        #         container.register("db", DB.new)
+        #       end
         #     end
-        #   end
         #
-        #   # system/providers/db.rb
-        #   #
-        #   # Provider registration which uses another provider
-        #   MyApp.register_provider(:db) do |container|
-        #     use :logger
-        #
-        #     start do
-        #       require "db"
-        #       DB.configure(ENV['DB_URL'], logger: logger)
-        #       container.register("db", DB.new)
+        #     # system/boot/db.rb
+        #     #
+        #     # Provider registration under a namespace. This will register the
+        #     # db object with the "persistence.db" key
+        #     MyApp.register_provider(:persistence, namespace: "db") do
+        #       start do
+        #         require "db"
+        #         DB.configure(ENV["DB_URL"])
+        #         register("db", DB.new)
+        #       end
         #     end
-        #   end
         #
-        #   # system/boot/db.rb
-        #   #
-        #   # Provider registration under a namespace. This will register the
-        #   # db object with the "persistence.db" key
-        #   MyApp.register_provider(:persistence, namespace: "db") do
-        #     require "db"
-        #     DB.configure(ENV["DB_URL"])
-        #     register("db", DB.new)
-        #   end
+        #   @param name [Symbol] a unique name for the provider
+        #   @param namespace [String, nil] the key namespace to use for any registrations
+        #     made during the provider's lifecycle
+        #   @param from [Symbol, nil] the group for the external provider source (with the
+        #     provider source name inferred from `name` or passsed explicitly as
+        #     `source:`)
+        #   @param source [Symbol, nil] the name of the external provider source to use
+        #     (if different from the value provided as `name`)
+        #   @param if [Boolean] a boolean to determine whether to register the provider
         #
-        # @param name [Symbol] a unique name for the provider
+        #   @see Provider
+        #   @see Provider::Source
         #
-        # @see ProviderLifecycle
+        #   @return [self]
         #
-        # @return [self]
-        #
-        # @api public
+        #   @api public
         def register_provider(...)
           providers.register_provider(...)
         end
 
+        # rubocop:enable Layout/LineLength
+
+        # @see .register_provider
+        # @api public
         def boot(name, **opts, &block)
           Dry::Core::Deprecations.announce(
             "Dry::System::Container.boot",

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -302,7 +302,11 @@ module Dry
           end
 
           provider_if = binding.local_variable_get(:if)
-          return self unless provider_if
+          if provider_if.respond_to?(:call)
+            return self unless provider_if.call(self)
+          else
+            return self unless provider_if
+          end
 
           provider =
             if from

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -301,12 +301,7 @@ module Dry
             raise ArgumentError, "You must supply only a `source:` option or a block, not both"
           end
 
-          provider_if = binding.local_variable_get(:if)
-          if provider_if.respond_to?(:call)
-            return self unless provider_if.call(self)
-          else
-            return self unless provider_if
-          end
+          return self unless binding.local_variable_get(:if)
 
           provider =
             if from

--- a/lib/dry/system/provider_registrar.rb
+++ b/lib/dry/system/provider_registrar.rb
@@ -186,15 +186,15 @@ module Dry
 
       private
 
-      # rubocop:disable Metrics/PerceivedComplexity, Layout/LineLength
+      # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Layout/LineLength
       # @api private
       def provider_paths
         provider_dirs = container.config.provider_dirs
         bootable_dirs = container.config.bootable_dirs || ["system/boot"]
 
         if container.config.provider_dirs == ["system/providers"] && \
-            provider_dirs.none? { |d| container.root.join(d).exist? } && \
-            bootable_dirs.any? { |d| container.root.join(d).exist? }
+           provider_dirs.none? { |d| container.root.join(d).exist? } && \
+           bootable_dirs.any? { |d| container.root.join(d).exist? }
           Dry::Core::Deprecations.announce(
             "Dry::System::Container.config.bootable_dirs (defaulting to 'system/boot')",
             "Use `Dry::System::Container.config.provider_dirs` (defaulting to 'system/providers') instead",
@@ -215,10 +215,14 @@ module Dry
           end
         }
       end
-      # rubocop:enable Metrics/PerceivedComplexity, Layout/LineLength
+      # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Layout/LineLength
 
       def build_provider(name, namespace:, source: nil, &block)
-        source_class = source || Provider::Source.for(name: name, target_container: container, &block)
+        source_class = source || Provider::Source.for(
+          name: name,
+          target_container: container,
+          &block
+        )
 
         Provider.new(
           name: name,

--- a/spec/integration/container/providers/conditional_providers_spec.rb
+++ b/spec/integration/container/providers/conditional_providers_spec.rb
@@ -1,41 +1,52 @@
 # frozen_string_literal: true
 
 RSpec.describe "Providers / Conditional providers" do
-  describe "conditional on simple values" do
-    let(:container) {
-      provider_if = self.provider_if
-      Class.new(Dry::System::Container) {
-        register_provider :provided, if: provider_if do
-          start do
-            register "provided", Object.new
-          end
-        end
-      }
-    }
+  let(:container) {
+    provider_if = self.provider_if
+    Class.new(Dry::System::Container) {
+      def self.load_the_provider?(name)
+        false
+      end
 
+      register_provider :provided, if: provider_if do
+        start do
+          register "provided", Object.new
+        end
+      end
+    }
+  }
+
+  shared_examples "loads the provider" do
+    it "registers the provider" do
+      expect(container.providers.key?(:provided)).to be true
+    end
+
+    it "runs the provider" do
+      expect(container["provided"]).to be
+    end
+  end
+
+  shared_examples "does not load the provider" do
+    it "does not register the provider" do
+      expect(container.providers.key?(:provided)).to be false
+    end
+
+    it "does not run the provider" do
+      expect { container["provided"] }.to raise_error(Dry::Container::Error, /Nothing registered/)
+    end
+  end
+
+  describe "conditional on simple values" do
     describe "true" do
       let(:provider_if) { true }
 
       context "lazy loading" do
-        it "registers the provider" do
-          expect(container.providers.key?(:provided)).to be true
-        end
-
-        it "runs the provider" do
-          expect(container["provided"]).to be
-        end
+        include_examples "loads the provider"
       end
 
       context "finalized" do
         before { container.finalize! }
-
-        it "registers the provider" do
-          expect(container.providers.key?(:provided)).to be true
-        end
-
-        it "runs the provider" do
-          expect(container["provided"]).to be
-        end
+        include_examples "loads the provider"
       end
     end
 
@@ -43,25 +54,63 @@ RSpec.describe "Providers / Conditional providers" do
       let(:provider_if) { false }
 
       context "lazy loading" do
-        it "does not register the provider" do
-          expect(container.providers.key?(:provided)).to be false
-        end
-
-        it "does not run the provider" do
-          expect { container["provided"] }.to raise_error(Dry::Container::Error, /Nothing registered/)
-        end
+        include_examples "does not load the provider"
       end
 
       context "finalized" do
         before { container.finalize! }
+        include_examples "does not load the provider"
+      end
+    end
+  end
 
-        it "does not register the provider" do
-          expect(container.providers.key?(:provided)).to be false
-        end
+  describe "conditional on proc" do
+    describe "proc returns true" do
+      let(:provider_if) { proc { true } }
 
-        it "does not register the provider" do
-          expect { container["provided"] }.to raise_error(Dry::Container::Error, /Nothing registered/)
-        end
+      context "lazy loading" do
+        include_examples "loads the provider"
+      end
+
+      context "finalized" do
+        before { container.finalize! }
+        include_examples "loads the provider"
+      end
+    end
+
+    describe "proc returns false" do
+      let(:provider_if) { proc { false } }
+
+      context "lazy loading" do
+        include_examples "does not load the provider"
+      end
+
+      context "finalized" do
+        before { container.finalize! }
+        include_examples "does not load the provider"
+      end
+    end
+
+    describe "lambda (or proc) accepting container as argument" do
+      let(:provider_if) {
+        lambda { |container| container.load_the_provider?(:provided) }
+      }
+
+      context "lazy loading" do
+        include_examples "does not load the provider"
+      end
+
+      context "finalized" do
+        before { container.finalize! }
+        include_examples "does not load the provider"
+      end
+    end
+
+    describe "lambda without arguments" do
+      let(:provider_if) { lambda { false } }
+
+      it "raises an argument error" do
+        expect { container }.to raise_error ArgumentError, /given 1, expected 0/
       end
     end
   end

--- a/spec/integration/container/providers/conditional_providers_spec.rb
+++ b/spec/integration/container/providers/conditional_providers_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Providers / Conditional providers" do
   let(:container) {
     provider_if = self.provider_if
     Class.new(Dry::System::Container) {
-      def self.load_the_provider?(name)
-        false
-      end
-
       register_provider :provided, if: provider_if do
         start do
           register "provided", Object.new
@@ -36,82 +32,29 @@ RSpec.describe "Providers / Conditional providers" do
     end
   end
 
-  describe "conditional on simple values" do
-    describe "true" do
-      let(:provider_if) { true }
+  describe "true" do
+    let(:provider_if) { true }
 
-      context "lazy loading" do
-        include_examples "loads the provider"
-      end
-
-      context "finalized" do
-        before { container.finalize! }
-        include_examples "loads the provider"
-      end
+    context "lazy loading" do
+      include_examples "loads the provider"
     end
 
-    describe "false" do
-      let(:provider_if) { false }
-
-      context "lazy loading" do
-        include_examples "does not load the provider"
-      end
-
-      context "finalized" do
-        before { container.finalize! }
-        include_examples "does not load the provider"
-      end
+    context "finalized" do
+      before { container.finalize! }
+      include_examples "loads the provider"
     end
   end
 
-  describe "conditional on proc" do
-    describe "proc returns true" do
-      let(:provider_if) { proc { true } }
+  describe "false" do
+    let(:provider_if) { false }
 
-      context "lazy loading" do
-        include_examples "loads the provider"
-      end
-
-      context "finalized" do
-        before { container.finalize! }
-        include_examples "loads the provider"
-      end
+    context "lazy loading" do
+      include_examples "does not load the provider"
     end
 
-    describe "proc returns false" do
-      let(:provider_if) { proc { false } }
-
-      context "lazy loading" do
-        include_examples "does not load the provider"
-      end
-
-      context "finalized" do
-        before { container.finalize! }
-        include_examples "does not load the provider"
-      end
-    end
-
-    describe "lambda (or proc) accepting container as argument" do
-      let(:provider_if) {
-        lambda { |container| container.load_the_provider?(:provided) }
-      }
-
-      context "lazy loading" do
-        include_examples "does not load the provider"
-      end
-
-      context "finalized" do
-        before { container.finalize! }
-        include_examples "does not load the provider"
-      end
-    end
-
-    describe "lambda without arguments" do
-      let(:provider_if) { lambda { false } }
-
-      it "raises an argument error" do
-        expect { container }.to raise_error ArgumentError, /given 1, expected 0/
-      end
+    context "finalized" do
+      before { container.finalize! }
+      include_examples "does not load the provider"
     end
   end
 end

--- a/spec/integration/container/providers/conditional_providers_spec.rb
+++ b/spec/integration/container/providers/conditional_providers_spec.rb
@@ -13,22 +13,16 @@ RSpec.describe "Providers / Conditional providers" do
   }
 
   shared_examples "loads the provider" do
-    it "registers the provider" do
-      expect(container.providers.key?(:provided)).to be true
-    end
-
-    it "runs the provider" do
+    it "runs the provider when a related component is resolved" do
       expect(container["provided"]).to be
+      expect(container.providers.key?(:provided)).to be true
     end
   end
 
   shared_examples "does not load the provider" do
-    it "does not register the provider" do
-      expect(container.providers.key?(:provided)).to be false
-    end
-
-    it "does not run the provider" do
+    it "does not run the provider when a related component is resolved" do
       expect { container["provided"] }.to raise_error(Dry::Container::Error, /Nothing registered/)
+      expect(container.providers.key?(:provided)).to be false
     end
   end
 
@@ -55,6 +49,63 @@ RSpec.describe "Providers / Conditional providers" do
     context "finalized" do
       before { container.finalize! }
       include_examples "does not load the provider"
+    end
+  end
+
+  describe "provider file in provider dir" do
+    let(:container) {
+      root = @dir
+      Test::Container = Class.new(Dry::System::Container) {
+        configure do |config|
+          config.root = root
+        end
+      }
+    }
+
+    describe "true" do
+      before :context do
+        with_directory(@dir = make_tmp_directory) do
+          write "system/providers/provided.rb", <<~RUBY
+            Test::Container.register_provider :provided, if: true do
+              start do
+                register "provided", Object.new
+              end
+            end
+          RUBY
+        end
+      end
+
+      context "lazy loading" do
+        include_examples "loads the provider"
+      end
+
+      context "finalized" do
+        before { container.finalize! }
+        include_examples "loads the provider"
+      end
+    end
+
+    describe "true" do
+      before :context do
+        with_directory(@dir = make_tmp_directory) do
+          write "system/providers/provided.rb", <<~RUBY
+            Test::Container.register_provider :provided, if: false do
+              start do
+                register "provided", Object.new
+              end
+            end
+          RUBY
+        end
+      end
+
+      context "lazy loading" do
+        include_examples "does not load the provider"
+      end
+
+      context "finalized" do
+        before { container.finalize! }
+        include_examples "does not load the provider"
+      end
     end
   end
 end

--- a/spec/integration/container/providers/conditional_providers_spec.rb
+++ b/spec/integration/container/providers/conditional_providers_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe "Providers / Conditional providers" do
+  describe "conditional on simple values" do
+    let(:container) {
+      provider_if = self.provider_if
+      Class.new(Dry::System::Container) {
+        register_provider :provided, if: provider_if do
+          start do
+            register "provided", Object.new
+          end
+        end
+      }
+    }
+
+    describe "true" do
+      let(:provider_if) { true }
+
+      context "lazy loading" do
+        it "registers the provider" do
+          expect(container.providers.key?(:provided)).to be true
+        end
+
+        it "runs the provider" do
+          expect(container["provided"]).to be
+        end
+      end
+
+      context "finalized" do
+        before { container.finalize! }
+
+        it "registers the provider" do
+          expect(container.providers.key?(:provided)).to be true
+        end
+
+        it "runs the provider" do
+          expect(container["provided"]).to be
+        end
+      end
+    end
+
+    describe "false" do
+      let(:provider_if) { false }
+
+      context "lazy loading" do
+        it "does not register the provider" do
+          expect(container.providers.key?(:provided)).to be false
+        end
+
+        it "does not run the provider" do
+          expect { container["provided"] }.to raise_error(Dry::Container::Error, /Nothing registered/)
+        end
+      end
+
+      context "finalized" do
+        before { container.finalize! }
+
+        it "does not register the provider" do
+          expect(container.providers.key?(:provided)).to be false
+        end
+
+        it "does not register the provider" do
+          expect { container["provided"] }.to raise_error(Dry::Container::Error, /Nothing registered/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow providers to be conditionally registered based on a new `if:` argument for `Container.register_provider`.

The value for `if:` is expected to be a simple truthy or falsey value only. It defaults to `true` when not provided.

This feature is valuable because it allows certain providers, which may only be needed in certain runtime contexts (i.e. when the container is left lazy loading and those providers or dependent components are accessed directly) to be skipped when finalizing the container to run the "main" parts of the app. For example, there may be a provider required purely for a subset of background jobs, which will be loaded when running the jobs worker, but is not needed at all when the main web application is run via Puma and a finalised container.

In this PR we also move all provider-registration-related methods and logic from `Container` into `ProviderRegistrar`, which helps to make `Container` considerably shorter, while also keeping all provider registration logic together inside `ProviderRegistrar`.

In terms of implementation, I toyed for a moment (see [this commit](https://github.com/dry-rb/dry-system/pull/218/commits/196fe2985c29523cec7d487ddc866cd24746687e)) with allowing a proc to be passed here, but given the implementation had the proc immediately evaluated (and passed the container object, which the user already has access to given it's the receiver for `register_provider`), I feel it wasn't adding any value. For this feature I think I'd rather keep it simple to start with, and then consider evolution of the behavior based on real experience and user feedback.

Resolves #94, resolves #95