### PR TITLE
Allow Zeitwerk::Loader#setup to be run externally

### DIFF
--- a/lib/dry/system/plugins.rb
+++ b/lib/dry/system/plugins.rb
@@ -21,8 +21,8 @@ module Dry
         end
 
         # @api private
-        def apply_to(system, options)
-          system.extend(stateful? ? mod.new(options) : mod)
+        def apply_to(system, **options)
+          system.extend(stateful? ? mod.new(**options) : mod)
           system.instance_eval(&block) if block
           system
         end
@@ -90,13 +90,13 @@ module Dry
       # @return [self]
       #
       # @api public
-      def use(name, options = {})
+      def use(name, **options)
         return self if enabled_plugins.include?(name)
 
         raise PluginNotFoundError, name unless (plugin = Plugins.registry[name])
 
         plugin.load_dependencies
-        plugin.apply_to(self, options)
+        plugin.apply_to(self, **options)
 
         enabled_plugins << name
 

--- a/lib/dry/system/plugins/env.rb
+++ b/lib/dry/system/plugins/env.rb
@@ -10,8 +10,9 @@ module Dry
         attr_reader :options
 
         # @api private
-        def initialize(options)
+        def initialize(**options)
           @options = options
+          super()
         end
 
         def inferrer


### PR DESCRIPTION
This is useful if external integrating systems (e.g. Hanami) want to use the Zeitwerk plugin for configuring the loader, but want to call `#setup` at a different time.