### PR TITLE
[Proof of concept] Component isolation

### DIFF
--- a/lib/dry/system/loader.rb
+++ b/lib/dry/system/loader.rb
@@ -41,16 +41,25 @@ module Dry
         # @return [Object]
         #
         # @api public
-        def call(component, *args)
+        def call(component, *args, isolate: false)
           require!(component)
 
           constant = self.constant(component)
 
-          if singleton?(constant)
+          instance = if singleton?(constant)
             constant.instance(*args)
           else
             constant.new(*args)
           end
+
+          if isolate
+            constant_name_parts = constant.to_s.split("::")
+            namespace = constant_name_parts.slice(0..-2).join("::")
+            namespace_const = component.inflector.constantize(namespace)
+            namespace_const.send(:remove_const, constant_name_parts.last)
+          end
+
+          instance
         end
         ruby2_keywords(:call) if respond_to?(:ruby2_keywords, true)
 

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe Dry::System::Loader do
       end
 
       it_behaves_like "object loader"
+
+      it "isolates component by removing its constant" do
+        constant
+        instance = loader.call(component, isolate: true)
+        expect(Test.const_defined?("Bar")).to eq(false)
+        expect(instance).to be_a(constant)
+      end
     end
 
     context "with a constructor accepting args" do


### PR DESCRIPTION
dry-system provides a nice container for creating new instances of classes, but it doesn't enforce its use. Developers are free to create an object by calling its constant constructor (e.g. `Foo.new`)

_...until now..._ 😱 

With this proposed 'isolation' feature, a component's constant would be removed right after it's loaded, so the users would **not** be able to call `Foo.new`. Or call `Foo` at all. That is, they would _have_ to use the container to create new instances.

This may be a very bad idea... it may be going _too far_. It may have negative unintended consequences. I could see it being useful in some circumstances though. The idea is to remove more global state, by having fewer constants.

This is clearly just a proof of concept. It could be a post-1.0 feature, too. If we wanted to implement this for real, some things (among more, I'm sure) we'd have to consider:

- How would this be configured? Per component, per component_dir, per container? 
- Should this be a custom `Loader`? i.e. provided as a subclass of Loader, either in this gem or as an external one
- Is this the right place to do this?
- Is isolate/isolation the right name?
- Do we want to go further, and load the class definitions once and store them internally somehow, and remove the constants then, once?