### PR TITLE
Raise error when import is called on finalized container

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -171,26 +171,31 @@ module Dry
         #
         # @example
         #   # system/container.rb
+        #   require "dry/system/container"
+        #   require "logger"
+        #
         #   class Core < Dry::System::Container
-        #     configure do |config|
-        #       config.root = Pathname("/path/to/app")
-        #       config.auto_register = %w(lib/apis lib/core)
-        #     end
+        #     register("logger", Logger.new($stdout))
         #   end
         #
         #   # apps/my_app/system/container.rb
         #   require 'system/container'
         #
         #   class MyApp < Dry::System::Container
-        #     configure do |config|
-        #       config.root = Pathname("/path/to/app")
-        #       config.auto_register = %w(lib/apis lib/core)
-        #     end
-        #
-        #     import core: Core
+        #     import(from: Core, as: :core)
         #   end
         #
-        # @param other [Hash, Dry::Container::Namespace]
+        #   MyApp.import(keys: ["logger"], from: Core, as: :core2)
+        #
+        #   MyApp["core.logger"].info("Test")
+        #   MyApp["core2.logger"].info("Test2")
+        #
+        # @param keys [Array<String>] Keys to use for partial importing components from the container
+        # @param from [Class] The container to import from
+        # @param as [Symbol] Namespace to use for the components of the imported container
+        #
+        # @raise [Dry::System::ContainerAlreadyFinalizedError] if the container has already
+        #  been finalized
         #
         # @api public
         def import(keys: nil, from: nil, as: nil, **deprecated_import_hash)

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -194,6 +194,8 @@ module Dry
         #
         # @api public
         def import(keys: nil, from: nil, as: nil, **deprecated_import_hash)
+          raise Dry::System::ContainerAlreadyFinalizedError if finalized?
+
           if deprecated_import_hash.any?
             Dry::Core::Deprecations.announce(
               "Dry::System::Container.import with {namespace => container} hash",

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -6,6 +6,11 @@ module Dry
   module System
     extend Dry::Core::Deprecations["dry-system"]
 
+    # Error raised when import is called on an already finalized container
+    #
+    # @api public
+    ContainerAlreadyFinalizedError = Class.new(StandardError)
+
     # Error raised when a component dir is added to configuration more than once
     #
     # @api public

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Dry::System::Container, ".import" do
     expect(app["persistence.users"]).to eql(%w[jane joe])
   end
 
+  context "when container has been finalized" do
+    it "raises an error" do
+      app.finalize!
+
+      expect do
+        app.import(from: db, as: :persistence)
+      end.to raise_error(Dry::System::ContainerAlreadyFinalizedError)
+    end
+  end
+
   describe "import module" do
     it "loads system when it was not loaded in the imported container yet" do
       class Test::Other < Dry::System::Container


### PR DESCRIPTION
Let me know whether the error should have another name, I thought the name `ContainerAlreadyFinalizedError` is adequate as it can be reused in the future for any operation on a finalized container which should raise.

I've also found the yard doc on `Dry::System::Container.import` is outdated, let me know if I should update that. Found the description in PR https://github.com/dry-rb/dry-system/pull/209 quite helpful and I could start to transfer some bits and pieces of it into the doc.

Closes #228