### PR TITLE
Fix incorrect type in ManifestRegistrar#finalize!

### DIFF
--- a/lib/dry/system/manifest_registrar.rb
+++ b/lib/dry/system/manifest_registrar.rb
@@ -27,7 +27,7 @@ module Dry
       # @api private
       def finalize!
         ::Dir[registrations_dir.join(RB_GLOB)].sort.each do |file|
-          call(File.basename(file, RB_EXT))
+          call(Identifier.new(File.basename(file, RB_EXT)))
         end
       end
 

--- a/spec/integration/container/auto_registration/component_dir_namespaces/autoloading_loader_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/autoloading_loader_spec.rb
@@ -4,6 +4,8 @@ require "dry/system/loader/autoloading"
 require "zeitwerk"
 
 RSpec.describe "Component dir namespaces / Autoloading loader" do
+  include ZeitwerkHelpers
+
   let(:container) {
     root = @dir
     dir_config = defined?(component_dir_config) ? component_dir_config : -> * {}
@@ -21,15 +23,7 @@ RSpec.describe "Component dir namespaces / Autoloading loader" do
 
   let(:loader) { Zeitwerk::Loader.new }
 
-  after do
-    Zeitwerk::Registry.loaders.each(&:unload)
-
-    Zeitwerk::Registry.loaders.clear
-    Zeitwerk::Registry.loaders_managing_gems.clear
-
-    Zeitwerk::ExplicitNamespace.cpaths.clear
-    Zeitwerk::ExplicitNamespace.tracer.disable
-  end
+  after { teardown_zeitwerk }
 
   context "top-level constant namespace" do
     let(:component_dir_config) {

--- a/spec/integration/container/lazy_loading/manifest_registration_spec.rb
+++ b/spec/integration/container/lazy_loading/manifest_registration_spec.rb
@@ -13,8 +13,19 @@ RSpec.describe "Lazy-loading registration manifest files" do
     end
   end
 
-  it "loads a registration manifest file if the component could not be found" do
-    expect(Test::Container["foo.special"]).to be_a(Test::Foo)
-    expect(Test::Container["foo.special"].name).to eq "special"
+  shared_examples "manifest component" do
+    it "loads a registration manifest file if the component could not be found" do
+      expect(Test::Container["foo.special"]).to be_a(Test::Foo)
+      expect(Test::Container["foo.special"].name).to eq "special"
+    end
+  end
+
+  context "Non-finalized container" do
+    include_examples "manifest component"
+  end
+
+  context "Finalized container" do
+    before { Test::Container.finalize! }
+    include_examples "manifest component"
   end
 end

--- a/spec/support/zeitwerk_helpers.rb
+++ b/spec/support/zeitwerk_helpers.rb
@@ -7,7 +7,15 @@ module ZeitwerkHelpers
     Zeitwerk::Registry.loaders.each(&:unload)
 
     Zeitwerk::Registry.loaders.clear
-    Zeitwerk::Registry.loaders_managing_gems.clear
+
+    # This private interface changes between 2.5.4 and 2.6.0
+    if Zeitwerk::Registry.respond_to?(:loaders_managing_gems)
+      Zeitwerk::Registry.loaders_managing_gems.clear
+    else
+      Zeitwerk::Registry.gem_loaders_by_root_file.clear
+      Zeitwerk::Registry.autoloads.clear
+      Zeitwerk::Registry.inceptions.clear
+    end
 
     Zeitwerk::ExplicitNamespace.cpaths.clear
     Zeitwerk::ExplicitNamespace.tracer.disable


### PR DESCRIPTION
`#finalize!` is sending the basename directly to `#call`, which expects a `Dry::System::Identifier`.

This means that if you configure a `registrations_dir`, putting any file in that directory will lead to an exception during finalization.

This appears to have been introduced during #181  