### PR TITLE
Import root components via `nil` import namespace

### DIFF
--- a/spec/integration/container/importing/container_registration_spec.rb
+++ b/spec/integration/container/importing/container_registration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Container / Imports / Registration" do
+RSpec.describe "Container / Imports / Container registration" do
   let(:exporting_container) {
     Class.new(Dry::System::Container) {
       register "block_component" do

--- a/spec/integration/container/importing/import_namespaces_spec.rb
+++ b/spec/integration/container/importing/import_namespaces_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe "Container / Imports / Import namespaces" do
+  before :context do
+    @dir = make_tmp_directory
+
+    with_directory @dir do
+      write "lib/exportable_component_a.rb", <<~RUBY
+        module Test
+          class ExportableComponentA; end
+        end
+      RUBY
+
+      write "lib/nested/exportable_component_b.rb", <<~RUBY
+        module Test
+          module Nested
+            class ExportableComponentB; end
+          end
+        end
+      RUBY
+    end
+  end
+
+  let(:exporting_container) {
+    root = @dir
+    exports = self.exports if respond_to?(:exports)
+
+    Class.new(Dry::System::Container) {
+      configure do |config|
+        config.root = root
+        config.component_dirs.add "lib" do |dir|
+          dir.namespaces.add_root const: "test"
+        end
+        config.exports = exports if exports
+      end
+    }
+  }
+
+  context "nil namespace" do
+    context "no keys specified" do
+      let(:importing_container) {
+        exporting_container = self.exporting_container
+
+        Class.new(Dry::System::Container) {
+          import from: exporting_container, as: nil
+        }
+      }
+
+      context "importing container is lazy loading" do
+        it "imports all the components" do
+          expect(importing_container.key?("exportable_component_a")).to be true
+          expect(importing_container.key?("nested.exportable_component_b")).to be true
+          expect(importing_container.key?("non_existent")).to be false
+        end
+      end
+
+      context "importing container is finalized" do
+        before do
+          importing_container.finalize!
+        end
+
+        it "imports all the components" do
+          expect(importing_container.key?("exportable_component_a")).to be true
+          expect(importing_container.key?("nested.exportable_component_b")).to be true
+          expect(importing_container.key?("non_existent")).to be false
+        end
+      end
+    end
+
+    context "keys specified" do
+      let(:importing_container) {
+        exporting_container = self.exporting_container
+
+        Class.new(Dry::System::Container) {
+          import keys: ["exportable_component_a"], from: exporting_container, as: nil
+        }
+      }
+
+      context "importing container is lazy loading" do
+        it "imports the specified components only" do
+          expect(importing_container.key?("exportable_component_a")).to be true
+          expect(importing_container.key?("nested.exportable_component_b")).to be false
+        end
+      end
+
+      context "importing container is finalized" do
+        before do
+          importing_container.finalize!
+        end
+
+        it "imports the specified components only" do
+          expect(importing_container.key?("exportable_component_a")).to be true
+          expect(importing_container.key?("nested.exportable_component_b")).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this change, we can import components from one container to the root of another by providing a namespace of `nil` to the `import` directive:

```ruby
class MyContainer < Dry::System::Container
  # ...

  import from: SomeOtherContainer, as: nil
end
```

Generally, having your imports namespaced is a good practice, because it serves as a clear hint as to their origin. However, in some cases, it may be useful not to have a namespace. One such case is in our plans for Hanami 2.0, where we want a small selection of application-wide components (such as `"logger"` and `"inflector"`) to be available to every container with the same keys, so there can a consistency in the way they are addressed.