### PR TITLE
Fix compat with dry-container from main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
+gem "dry-container", github: "dry-rb/dry-container", branch: "main"
+
 # Remove verson constraint once latter versions release their -java packages
 gem "bootsnap", "= 1.4.9"
 gem "dotenv"

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -2,9 +2,9 @@
 
 require "pathname"
 
-require "dry-auto_inject"
-require "dry-configurable"
-require "dry-container"
+require "dry/configurable"
+require "dry/auto_inject"
+require "dry/container"
 require "dry/core/deprecations"
 require "dry/inflector"
 
@@ -70,12 +70,11 @@ module Dry
     #
     # @api public
     class Container
-      extend Dry::Configurable
       extend Dry::Container::Mixin
       extend Dry::System::Plugins
 
       setting :name
-      setting :root, default: Pathname.pwd.freeze, constructor: -> path { Pathname(path) }
+      setting :root, default: Pathname.pwd.freeze, constructor: ->(path) { Pathname(path) }
       setting :provider_dirs, default: ["system/providers"]
       setting :bootable_dirs # Deprecated for provider_dirs, see .provider_paths below
       setting :registrations_dir, default: "system/registrations"

--- a/spec/integration/container/lazy_loading/auto_registration_disabled_spec.rb
+++ b/spec/integration/container/lazy_loading/auto_registration_disabled_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe "Lazy loading components with auto-registration disabled" do
   end
 
   it "does not load the component" do
-    expect { Test::Container["entities.kitten"] }.to raise_error(Dry::Container::Error)
+    expect { Test::Container["entities.kitten"] }.to raise_error(Dry::Container::KeyError)
   end
 end

--- a/spec/integration/container/providers/conditional_providers_spec.rb
+++ b/spec/integration/container/providers/conditional_providers_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Providers / Conditional providers" do
 
   shared_examples "does not load the provider" do
     it "does not run the provider when a related component is resolved" do
-      expect { container["provided"] }.to raise_error(Dry::Container::Error, /Nothing registered/)
+      expect { container["provided"] }.to raise_error(Dry::Container::KeyError, /key not found: "provided"/)
       expect(container.providers.key?(:provided)).to be false
     end
   end


### PR DESCRIPTION
This makes things work again with dry-container from main:

- Use the new `Dry::Container::KeyError` (`Error` is deprecated)
- Require `dry/configurable` before `dry/container` so that `Configurable` is used as the config backend