### PR TITLE
Validate settings even if loader does not set value

### DIFF
--- a/lib/dry/system/provider_sources/settings/config.rb
+++ b/lib/dry/system/provider_sources/settings/config.rb
@@ -41,7 +41,11 @@ module Dry
                 value = loader[setting_name.to_s.upcase]
 
                 begin
-                  settings_obj.config.public_send(:"#{setting_name}=", value) if value
+                  if value
+                    settings_obj.config.public_send(:"#{setting_name}=", value)
+                  else
+                    settings_obj.config[setting_name]
+                  end
                 rescue => e # rubocop:disable Style/RescueStandardError
                   errors[setting_name] = e
                 end

--- a/spec/integration/deprecations/deprecated_settings_provider_source_key_spec.rb
+++ b/spec/integration/deprecations/deprecated_settings_provider_source_key_spec.rb
@@ -30,10 +30,16 @@ RSpec.describe "Deprecated :settings provider source `key`" do
     Test::Container
   }
 
-  it "defines the setting" do
+  before do
     ENV["SOME_INT_USING_DEPRECATED_KEY"] = "5"
-    expect(container[:settings].some_int_using_deprecated_key).to eq 5
+  end
+
+  after do
     ENV.delete("SOME_INT_USING_DEPRECATED_KEY")
+  end
+
+  it "defines the setting" do
+    expect(container[:settings].some_int_using_deprecated_key).to eq 5
   end
 
   it "prints a deprecation notice" do


### PR DESCRIPTION
Resolves #245 

This is probably not the right way to solve this, but it gives the intended effect.