### PR TITLE
Update config in configure blocks only

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,6 +155,9 @@ Style/LambdaCall:
 Style/ParallelAssignment:
   Enabled: false
 
+Style/RaiseArgs:
+  Enabled: false
+
 Style/StabbyLambdaParentheses:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ eval_gemfile "Gemfile.devtools"
 gemspec
 
 gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only" # rubocop:disable Layout/LineLength
-gem "dry-core", github: "dry-rb/dry-core"
 
 # Remove verson constraint once latter versions release their -java packages
 gem "bootsnap", "= 1.4.9"

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
-gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only"
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only" # rubocop:disable Layout/LineLength
 gem "dry-core", github: "dry-rb/dry-core"
 
 # Remove verson constraint once latter versions release their -java packages

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only"
+gem "dry-core", github: "dry-rb/dry-core"
+
 # Remove verson constraint once latter versions release their -java packages
 gem "bootsnap", "= 1.4.9"
 gem "dotenv"

--- a/dry-system.gemspec
+++ b/dry-system.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-auto_inject", ">= 0.4.0"
   spec.add_runtime_dependency "dry-configurable", "~> 0.14", ">= 0.14.0"
   spec.add_runtime_dependency "dry-container", "~> 0.9", ">= 0.9.0"
-  spec.add_runtime_dependency "dry-core", ">= 0.9"
+  spec.add_runtime_dependency "dry-core", "~> 0.5", ">= 0.5"
   spec.add_runtime_dependency "dry-inflector", "~> 0.1", ">= 0.1.2"
 
   spec.add_development_dependency "bundler"

--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -267,7 +267,7 @@ module Dry
             # namespaces have been added
             !config.namespaces.empty?
           else
-            config._settings[key].input_defined?
+            _values.key?(key)
           end
         end
 

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -111,7 +111,7 @@ module Dry
 
         # @api private
         def initialize_copy(source)
-          @dirs = source.dirs.map { |path, dir| [path, dir.dup] }.to_h
+          @dirs = source.dirs.to_h { |path, dir| [path, dir.dup] }
           @defaults = source.defaults.dup
         end
 

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -268,7 +268,7 @@ module Dry
         def apply_defaults_to_dir(dir)
           defaults.config.values.each do |key, _|
             if defaults.configured?(key) && !dir.configured?(key)
-              dir.public_send(:"#{key}=", defaults.public_send(key).dup)
+              dir.public_send(:"#{key}=", defaults.public_send(key))
             end
           end
         end

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -22,7 +22,7 @@ module Dry
         end
 
         # @api private
-        def initialize_copy(source)
+        private def initialize_copy(source)
           super
           @namespaces = source.namespaces.dup
         end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -125,7 +125,6 @@ module Dry
         #
         # @api public
         def configure!(&block)
-          # FIXME: needs tests
           raise ContainerAlreadyConfiguredError.new(self) if configured?
 
           configure(&block)
@@ -151,6 +150,9 @@ module Dry
           return self if configured?
 
           hooks[:after_configure].each { |hook| instance_eval(&hook) }
+
+          _configurable_finalize!
+
           @__configured__ = true
 
           self
@@ -331,6 +333,11 @@ module Dry
         def finalized?
           @__finalized__.equal?(true)
         end
+
+        # Finalizes the config for this container
+        #
+        # @api private
+        alias_method :_configurable_finalize!, :finalize!
 
         # Finalizes the container
         #

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -6,6 +6,16 @@ module Dry
   module System
     extend Dry::Core::Deprecations["dry-system"]
 
+    Error = Class.new(StandardError)
+
+    # Error raised when further configuration is attempted on a container after it has been marked
+    # as configured
+    ContainerAlreadyConfiguredError = Class.new(Error) do
+      def initialize(container)
+        super("Container #{container} has already been marked as configured")
+      end
+    end
+
     # Error raised when a component dir is added to configuration more than once
     #
     # @api public

--- a/lib/dry/system/plugins/logging.rb
+++ b/lib/dry/system/plugins/logging.rb
@@ -40,10 +40,13 @@ module Dry
           elsif config.logger
             register(:logger, config.logger)
           else
-            config.logger = config.logger_class.new(log_file_path)
-            config.logger.level = log_level
+            configure do |config|
+              config.logger = config.logger_class.new(log_file_path)
+              config.logger.level = log_level
+            end
 
             register(:logger, config.logger)
+
             self
           end
         end

--- a/lib/dry/system/plugins/zeitwerk.rb
+++ b/lib/dry/system/plugins/zeitwerk.rb
@@ -32,9 +32,11 @@ module Dry
         def extended(system)
           system.setting :autoloader, reader: true
 
-          system.config.autoloader = loader
-          system.config.component_dirs.loader = Dry::System::Loader::Autoloading
-          system.config.component_dirs.add_to_load_path = false
+          system.configure do |config|
+            config.autoloader = loader
+            config.component_dirs.loader = Dry::System::Loader::Autoloading
+            config.component_dirs.add_to_load_path = false
+          end
 
           system.after(:configure, &method(:setup_autoloader))
 

--- a/spec/integration/container/auto_registration/component_dir_namespaces/deep_namespace_paths_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/deep_namespace_paths_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Component dir namespaces / Deep namespace paths" do
     dir_config = defined?(component_dir_config) ? component_dir_config : -> * {}
 
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add("lib", &dir_config)
       end

--- a/spec/integration/container/auto_registration/component_dir_namespaces/default_loader_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/default_loader_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Component dir namespaces / Default loader" do
     dir_config = defined?(component_dir_config) ? component_dir_config : -> * {}
 
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add("lib", &dir_config)
       end

--- a/spec/integration/container/auto_registration/component_dir_namespaces/multiple_namespaces_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/multiple_namespaces_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Component dir namespaces / Multiple namespaces" do
     dir_config = defined?(component_dir_config) ? component_dir_config : -> * {}
 
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add("lib", &dir_config)
       end

--- a/spec/integration/container/auto_registration/component_dir_namespaces/namespaces_as_defaults_spec.rb
+++ b/spec/integration/container/auto_registration/component_dir_namespaces/namespaces_as_defaults_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Component dir namespaces / Namespaces as component dir defaults"
     cont_config = defined?(container_config) ? container_config : -> * {}
 
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = root
 
         cont_config.(config)

--- a/spec/integration/container/auto_registration/custom_auto_register_proc_spec.rb
+++ b/spec/integration/container/auto_registration/custom_auto_register_proc_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Auto-registration / Custom auto_register proc" do
   before do
     class Test::Container < Dry::System::Container
-      configure do |config|
+      configure! do |config|
         config.root = SPEC_ROOT.join("fixtures").realpath
 
         config.component_dirs.add "components" do |dir|

--- a/spec/integration/container/auto_registration/memoize_spec.rb
+++ b/spec/integration/container/auto_registration/memoize_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Auto-registration / Memoizing components" do
   describe "Memoizing all components in a component directory" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
 
           config.component_dirs.add "components" do |dir|
@@ -43,7 +43,7 @@ RSpec.describe "Auto-registration / Memoizing components" do
   describe "Memoizing specific components in a component directory with a memoize proc" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
 
           config.component_dirs.add "components" do |dir|
@@ -91,7 +91,7 @@ RSpec.describe "Auto-registration / Memoizing components" do
     context "No memoizing config for component_dir" do
       before do
         class Test::Container < Dry::System::Container
-          configure do |config|
+          configure! do |config|
             config.root = SPEC_ROOT.join("fixtures").realpath
             config.component_dirs.add "memoize_magic_comments" do |dir|
               dir.namespaces.add "test", key: nil
@@ -110,7 +110,7 @@ RSpec.describe "Auto-registration / Memoizing components" do
     context "Memoize config 'false' for component_dir" do
       before do
         class Test::Container < Dry::System::Container
-          configure do |config|
+          configure! do |config|
             config.root = SPEC_ROOT.join("fixtures").realpath
             config.component_dirs.add "memoize_magic_comments" do |dir|
               dir.namespaces.add "test", key: nil
@@ -130,7 +130,7 @@ RSpec.describe "Auto-registration / Memoizing components" do
     context "Memoize config 'true' for component_dir" do
       before do
         class Test::Container < Dry::System::Container
-          configure do |config|
+          configure! do |config|
             config.root = SPEC_ROOT.join("fixtures").realpath
             config.component_dirs.add "memoize_magic_comments" do |dir|
               dir.namespaces.add "test", key: nil

--- a/spec/integration/container/auto_registration/mixed_namespaces_spec.rb
+++ b/spec/integration/container/auto_registration/mixed_namespaces_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Auto-registration / Components with mixed namespaces" do
   before do
     class Test::Container < Dry::System::Container
-      configure do |config|
+      configure! do |config|
         config.root = SPEC_ROOT.join("fixtures/mixed_namespaces").realpath
 
         config.component_dirs.add "lib" do |dir|

--- a/spec/integration/container/auto_registration_spec.rb
+++ b/spec/integration/container/auto_registration_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Auto-registration" do
   specify "Resolving components from a non-finalized container, without a default namespace" do
     module Test
       class Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/standard_container_without_default_namespace").realpath
           config.component_dirs.add "lib"
         end
@@ -25,7 +25,7 @@ RSpec.describe "Auto-registration" do
   specify "Resolving components from a non-finalized container, with a default namespace" do
     module Test
       class Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/standard_container_with_default_namespace").realpath
           config.component_dirs.add "lib" do |dir|
             dir.namespaces.add "test", key: nil

--- a/spec/integration/container/autoloading_spec.rb
+++ b/spec/integration/container/autoloading_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe "Autoloading loader" do
   specify "Resolving components using Zeitwerk" do
     module Test
       class Container < Dry::System::Container
-        config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
-        config.component_dirs.loader = Dry::System::Loader::Autoloading
-        config.component_dirs.add "lib" do |dir|
-          dir.add_to_load_path = false
-          dir.namespaces.add "test", key: nil
+        configure! do |config|
+          config.root = SPEC_ROOT.join("fixtures/autoloading").realpath
+          config.component_dirs.loader = Dry::System::Loader::Autoloading
+          config.component_dirs.add "lib" do |dir|
+            dir.add_to_load_path = false
+            dir.namespaces.add "test", key: nil
+          end
         end
       end
     end

--- a/spec/integration/container/importing/exports_spec.rb
+++ b/spec/integration/container/importing/exports_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Container / Imports / Exports" do
     exports = self.exports if respond_to?(:exports)
 
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add "lib" do |dir|
           dir.namespaces.add_root const: "test"

--- a/spec/integration/container/importing/import_namespaces_spec.rb
+++ b/spec/integration/container/importing/import_namespaces_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Container / Imports / Import namespaces" do
     exports = self.exports if respond_to?(:exports)
 
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add "lib" do |dir|
           dir.namespaces.add_root const: "test"

--- a/spec/integration/container/importing/partial_imports_spec.rb
+++ b/spec/integration/container/importing/partial_imports_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Container / Imports / Partial imports" do
     exports = self.exports if respond_to?(:exports)
 
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add "lib" do |dir|
           dir.namespaces.add_root const: "test"

--- a/spec/integration/container/lazy_loading/bootable_components_spec.rb
+++ b/spec/integration/container/lazy_loading/bootable_components_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Lazy loading bootable components" do
     before do
       module Test
         class Container < Dry::System::Container
-          configure do |config|
+          configure! do |config|
             config.root = SPEC_ROOT.join("fixtures/lazy_loading/shared_root_keys").realpath
             config.component_dirs.add "lib"
           end

--- a/spec/integration/container/plugins/dependency_graph_spec.rb
+++ b/spec/integration/container/plugins/dependency_graph_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Plugins / Dependency Graph" do
     Test::Container = Class.new(Dry::System::Container) {
       use :dependency_graph
 
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add "lib" do |dir|
           dir.namespaces.add_root const: "test"

--- a/spec/integration/container/plugins/logging_spec.rb
+++ b/spec/integration/container/plugins/logging_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Plugins / Logging" do
   before do
-    system.configure do |config|
+    system.configure! do |config|
       config.root = SPEC_ROOT.join("fixtures/test")
     end
   end

--- a/spec/integration/container/plugins/zeitwerk/eager_loading_spec.rb
+++ b/spec/integration/container/plugins/zeitwerk/eager_loading_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Zeitwerk plugin / Eager loading" do
       container = Class.new(Dry::System::Container) do
         use :zeitwerk, eager_load: true
 
-        configure do |config|
+        configure! do |config|
           config.root = tmp_dir
           config.component_dirs.add "lib" do |dir|
             dir.namespaces.add_root const: "test"
@@ -48,7 +48,7 @@ RSpec.describe "Zeitwerk plugin / Eager loading" do
         use :env, inferrer: -> { :production }
         use :zeitwerk
 
-        configure do |config|
+        configure! do |config|
           config.root = tmp_dir
           config.component_dirs.add "lib" do |dir|
             dir.namespaces.add_root const: "test"

--- a/spec/integration/container/plugins/zeitwerk/eager_loading_spec.rb
+++ b/spec/integration/container/plugins/zeitwerk/eager_loading_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/GlobalVars
 RSpec.describe "Zeitwerk plugin / Eager loading" do
   include ZeitwerkHelpers
 
@@ -60,3 +61,4 @@ RSpec.describe "Zeitwerk plugin / Eager loading" do
     end
   end
 end
+# rubocop:enable Style/GlobalVars

--- a/spec/integration/container/plugins/zeitwerk/namespaces_spec.rb
+++ b/spec/integration/container/plugins/zeitwerk/namespaces_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Zeitwerk plugin / Namespaces" do
       container = Class.new(Dry::System::Container) do
         use :zeitwerk
 
-        configure do |config|
+        configure! do |config|
           config.root = tmp_dir
 
           config.component_dirs.add "lib" do |dir|
@@ -56,7 +56,7 @@ RSpec.describe "Zeitwerk plugin / Namespaces" do
       container = Class.new(Dry::System::Container) do
         use :zeitwerk
 
-        configure do |config|
+        configure! do |config|
           config.root = tmp_dir
 
           config.component_dirs.add "lib" do |dir|

--- a/spec/integration/container/plugins/zeitwerk/resolving_components_spec.rb
+++ b/spec/integration/container/plugins/zeitwerk/resolving_components_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Zeitwerk plugin / Resolving components" do
       container = Class.new(Dry::System::Container) do
         use :zeitwerk
 
-        configure do |config|
+        configure! do |config|
           config.root = tmp_dir
           config.component_dirs.add "lib" do |dir|
             dir.namespaces.add_root const: "test"

--- a/spec/integration/container/plugins/zeitwerk/user_configured_loader_spec.rb
+++ b/spec/integration/container/plugins/zeitwerk/user_configured_loader_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Zeitwerk plugin / User-configured loader" do
       container = Class.new(Dry::System::Container) do
         use :zeitwerk
 
-        configure do |config|
+        configure! do |config|
           config.root = tmp_dir
           config.component_dirs.add "lib" do |dir|
             dir.namespaces.add_root const: "test"

--- a/spec/integration/container/plugins_spec.rb
+++ b/spec/integration/container/plugins_spec.rb
@@ -177,7 +177,9 @@ RSpec.describe Dry::System::Container, ".use" do
           setting :trace, default: []
 
           after(:configure) do
-            config.trace << :test_plugin_configured
+            configure do |config|
+              config.trace << :test_plugin_configured
+            end
           end
         end
       end
@@ -187,8 +189,8 @@ RSpec.describe Dry::System::Container, ".use" do
 
         descendant = Class.new(system)
 
-        system.configure {}
-        descendant.configure {}
+        system.configured!
+        descendant.configured!
 
         expect(system.config.trace).to eql([:test_plugin_configured])
         expect(descendant.config.trace).to eql([:test_plugin_configured])
@@ -201,13 +203,15 @@ RSpec.describe Dry::System::Container, ".use" do
           setting :trace, default: []
 
           after(:configure) do
-            config.trace << :test_plugin_configured
+            configure do |config|
+              config.trace << :test_plugin_configured
+            end
           end
         end
       end
 
       it "enables the plugin only once" do
-        system.use(:test_plugin).use(:test_plugin).configure {}
+        system.use(:test_plugin).use(:test_plugin).configured!
 
         expect(system.config.trace).to eql([:test_plugin_configured])
       end

--- a/spec/integration/container/providers/multiple_provider_dirs_spec.rb
+++ b/spec/integration/container/providers/multiple_provider_dirs_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe "Providers / Multiple provider dirs" do
   specify "Resolving provider files from multiple provider dirs" do
     module Test
       class Container < Dry::System::Container
-        config.root = SPEC_ROOT.join("fixtures/multiple_provider_dirs").realpath
+        configure! do |config|
+          config.root = SPEC_ROOT.join("fixtures/multiple_provider_dirs").realpath
 
-        config.provider_dirs = [
-          "custom_bootables", # Relative paths are appended to the container root
-          SPEC_ROOT.join("fixtures/multiple_provider_dirs/default_bootables")
-        ]
+          config.provider_dirs = [
+            "custom_bootables", # Relative paths are appended to the container root
+            SPEC_ROOT.join("fixtures/multiple_provider_dirs/default_bootables")
+          ]
+        end
       end
     end
 

--- a/spec/integration/container/providers/resolving_root_key_spec.rb
+++ b/spec/integration/container/providers/resolving_root_key_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Providers / Resolving components with same root key as a running
   before do
     root = @dir
     Test::Container = Class.new(Dry::System::Container) do
-      configure do |config|
+      configure! do |config|
         config.root = root
         config.component_dirs.add "lib" do |dir|
           dir.namespaces.add_root const: "test"

--- a/spec/integration/external_components_spec.rb
+++ b/spec/integration/external_components_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "External Components" do
   subject(:container) do
     module Test
       class Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/app").realpath
         end
 

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "Lazy-booting external deps" do
   before do
     module Test
       class Umbrella < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.name = :core
           config.root = SPEC_ROOT.join("fixtures/umbrella").realpath
         end
       end
 
       class App < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.name = :main
         end
       end

--- a/spec/unit/auto_registrar_spec.rb
+++ b/spec/unit/auto_registrar_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dry::System::AutoRegistrar, "#finalize!" do
 
   let(:container) {
     Class.new(Dry::System::Container) {
-      configure do |config|
+      configure! do |config|
         config.root = SPEC_ROOT.join("fixtures").realpath
         config.component_dirs.add "components" do |dir|
           dir.namespaces.add "test", key: nil

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -100,9 +100,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
 
     it { expect(Test::Container["foo"]).to be_an_instance_of(Test::Foo) }
     it { expect(Test::Container["bar"]).to eq(Test::Bar) }
-    it {
-      # byebug
-      expect(Test::Container["bar"].call).to eq("Welcome to my Moe's Tavern!") }
+    it { expect(Test::Container["bar"].call).to eq("Welcome to my Moe's Tavern!") }
     it { expect(Test::Container["bar.baz"]).to be_an_instance_of(Test::Bar::Baz) }
   end
 

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
   context "standard loader" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
           config.component_dirs.add "components" do |dir|
             dir.namespaces.add "test", key: nil
@@ -27,7 +27,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
   context "standard loader with a default namespace configured" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
           config.component_dirs.add "namespaced_components" do |dir|
             dir.namespaces.add "namespaced", key: nil
@@ -44,7 +44,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
   context "standard loader with default namespace but boot files without" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
 
           config.component_dirs.add "components" do |dir|
@@ -62,7 +62,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
   context "standard loader with a default namespace with multiple level" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
           config.component_dirs.add "multiple_namespaced_components" do |dir|
             dir.namespaces.add "multiple/level", key: nil
@@ -88,7 +88,7 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
       end
 
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
           config.component_dirs.loader = Test::Loader
           config.component_dirs.add "components" do |dir|
@@ -100,14 +100,16 @@ RSpec.describe Dry::System::Container, ".auto_register!" do
 
     it { expect(Test::Container["foo"]).to be_an_instance_of(Test::Foo) }
     it { expect(Test::Container["bar"]).to eq(Test::Bar) }
-    it { expect(Test::Container["bar"].call).to eq("Welcome to my Moe's Tavern!") }
+    it {
+      # byebug
+      expect(Test::Container["bar"].call).to eq("Welcome to my Moe's Tavern!") }
     it { expect(Test::Container["bar.baz"]).to be_an_instance_of(Test::Bar::Baz) }
   end
 
   context "when component directory is missing" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures").realpath
           config.component_dirs.add "components" do |dir|
             dir.namespaces.add "test", key: nil

--- a/spec/unit/container/configuration_spec.rb
+++ b/spec/unit/container/configuration_spec.rb
@@ -5,17 +5,17 @@ require "dry/system/container"
 RSpec.describe Dry::System::Container, "configuration phase" do
   subject(:container) { Class.new(described_class) }
 
-  describe "#configure" do
+  describe "#configure!" do
     it "configures the container" do
       expect {
-        container.configure do |config|
+        container.configure! do |config|
           config.root = "/root"
         end
       }.to change { container.config.root }.to Pathname("/root")
     end
 
     it "marks the container as configured" do
-      expect { container.configure {} }
+      expect { container.configure! {} }
         .to change { container.configured? }
         .from(false).to true
     end
@@ -31,47 +31,47 @@ RSpec.describe Dry::System::Container, "configuration phase" do
         end
       end
 
-      expect { container.configure {} }
+      expect { container.configure! {} }
         .to change { container.hooks_trace }
         .from([])
         .to [:after_configure]
     end
 
-    it "does not run after configure hooks when called a second time" do
-      container.instance_eval do
-        def hooks_trace
-          @hooks_trace ||= []
-        end
+    # it "does not run after configure hooks when called a second time" do
+    #   container.instance_eval do
+    #     def hooks_trace
+    #       @hooks_trace ||= []
+    #     end
 
-        after :configure do
-          hooks_trace << :after_configure
-        end
-      end
+    #     after :configure do
+    #       hooks_trace << :after_configure
+    #     end
+    #   end
 
-      expect { container.configure {}; container.configure {} }
-        .to change { container.hooks_trace }
-        .from([])
-        .to [:after_configure]
-    end
+    #   expect { container.configure! {}; container.configure! {} }
+    #     .to change { container.hooks_trace }
+    #     .from([])
+    #     .to [:after_configure]
+    # end
 
-    it "finalizes (freezes) the config" do
-      expect { container.configure {} }
-        .to change { container.config.frozen? }
-        .from(false).to true
+    # it "finalizes (freezes) the config" do
+    #   expect { container.configure! {} }
+    #     .to change { container.config.frozen? }
+    #     .from(false).to true
 
-      expect { container.configure { |c| c.root = "/root" } }
-        .to raise_error Dry::Configurable::FrozenConfig
-    end
+    #   expect { container.configure { |c| c.root = "/root" } }
+    #     .to raise_error FrozenError
+    # end
 
-    it "does not finalize the config with `finalize_config: false`" do
-      expect { container.configure(finalize_config: false) {} }
-        .not_to change { container.config.frozen? }
+    # it "does not finalize the config with `finalize_config: false`" do
+    #   expect { container.configure!(finalize_config: false) {} }
+    #     .not_to change { container.config.frozen? }
 
-      expect(container.config).not_to be_frozen
+    #   expect(container.config).not_to be_frozen
 
-      expect { container.configure { |c| c.root = "/root" } }
-        .not_to raise_error
-    end
+    #   expect { container.configure! { |c| c.root = "/root" } }
+    #     .not_to raise_error
+    # end
   end
 
   describe "#configured!" do
@@ -115,22 +115,22 @@ RSpec.describe Dry::System::Container, "configuration phase" do
         .to [:after_configure]
     end
 
-    it "finalizes (freezes) the config" do
-      expect { container.configured! }
-        .to change { container.config.frozen? }
-        .from(false).to true
+    # it "finalizes (freezes) the config" do
+    #   expect { container.configured! }
+    #     .to change { container.config.frozen? }
+    #     .from(false).to true
 
-      expect { container.config.root = "/root" }.to raise_error Dry::Configurable::FrozenConfig
-    end
+    #   expect { container.configure { |c| c.root = "/root" } }.to raise_error FrozenError
+    # end
 
-    it "does not finalize the config with `finalize_config: false`" do
-      expect { container.configured!(finalize_config: false) }
-        .not_to change { container.config.frozen? }
+    # it "does not finalize the config with `finalize_config: false`" do
+    #   expect { container.configured!(finalize_config: false) }
+    #     .not_to change { container.config.frozen? }
 
-      expect(container.config).not_to be_frozen
+    #   expect(container.config).not_to be_frozen
 
-      expect { container.config.root = "/root" }.not_to raise_error
-    end
+    #   expect { container.configure { |c| c.root = "/root" } }.not_to raise_error
+    # end
   end
 
   describe "#finalize!" do

--- a/spec/unit/container/configuration_spec.rb
+++ b/spec/unit/container/configuration_spec.rb
@@ -37,41 +37,10 @@ RSpec.describe Dry::System::Container, "configuration phase" do
         .to [:after_configure]
     end
 
-    # it "does not run after configure hooks when called a second time" do
-    #   container.instance_eval do
-    #     def hooks_trace
-    #       @hooks_trace ||= []
-    #     end
-
-    #     after :configure do
-    #       hooks_trace << :after_configure
-    #     end
-    #   end
-
-    #   expect { container.configure! {}; container.configure! {} }
-    #     .to change { container.hooks_trace }
-    #     .from([])
-    #     .to [:after_configure]
-    # end
-
-    # it "finalizes (freezes) the config" do
-    #   expect { container.configure! {} }
-    #     .to change { container.config.frozen? }
-    #     .from(false).to true
-
-    #   expect { container.configure { |c| c.root = "/root" } }
-    #     .to raise_error FrozenError
-    # end
-
-    # it "does not finalize the config with `finalize_config: false`" do
-    #   expect { container.configure!(finalize_config: false) {} }
-    #     .not_to change { container.config.frozen? }
-
-    #   expect(container.config).not_to be_frozen
-
-    #   expect { container.configure! { |c| c.root = "/root" } }
-    #     .not_to raise_error
-    # end
+    it "raises an error when run a second time" do
+      container.configure! {}
+      expect { container.configure! {} }.to raise_error(Dry::System::ContainerAlreadyConfiguredError)
+    end
   end
 
   describe "#configured!" do
@@ -115,22 +84,13 @@ RSpec.describe Dry::System::Container, "configuration phase" do
         .to [:after_configure]
     end
 
-    # it "finalizes (freezes) the config" do
-    #   expect { container.configured! }
-    #     .to change { container.config.frozen? }
-    #     .from(false).to true
+    it "finalizes the config" do
+      expect { container.configured! }
+        .to change { container.config.frozen? }
+        .from(false).to true
 
-    #   expect { container.configure { |c| c.root = "/root" } }.to raise_error FrozenError
-    # end
-
-    # it "does not finalize the config with `finalize_config: false`" do
-    #   expect { container.configured!(finalize_config: false) }
-    #     .not_to change { container.config.frozen? }
-
-    #   expect(container.config).not_to be_frozen
-
-    #   expect { container.configure { |c| c.root = "/root" } }.not_to raise_error
-    # end
+      expect { container.configure { |c| c.root = "/root" } }.to raise_error FrozenError
+    end
   end
 
   describe "#finalize!" do

--- a/spec/unit/container/hooks/load_path_hook_spec.rb
+++ b/spec/unit/container/hooks/load_path_hook_spec.rb
@@ -3,7 +3,9 @@
 RSpec.describe Dry::System::Container, "Default hooks / Load path" do
   let(:container) {
     Class.new(Dry::System::Container) {
-      config.root = SPEC_ROOT.join("fixtures/test")
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures/test")
+      end
     }
   }
 
@@ -17,13 +19,15 @@ RSpec.describe Dry::System::Container, "Default hooks / Load path" do
 
   context "component_dirs configured with add_to_load_path = true" do
     before do
-      container.config.component_dirs.add "lib" do |dir|
-        dir.add_to_load_path = true
+      container.configure do |config|
+        config.component_dirs.add "lib" do |dir|
+          dir.add_to_load_path = true
+        end
       end
     end
 
     it "adds the component dirs to the load path" do
-      expect { container.configure do; end }
+      expect { container.configured! }
         .to change { $LOAD_PATH.include?(SPEC_ROOT.join("fixtures/test/lib").to_s) }
         .from(false).to(true)
     end
@@ -31,8 +35,10 @@ RSpec.describe Dry::System::Container, "Default hooks / Load path" do
 
   context "component_dirs configured with add_to_load_path = false" do
     before do
-      container.config.component_dirs.add "lib" do |dir|
-        dir.add_to_load_path = false
+      container.configure do |config|
+        config.component_dirs.add "lib" do |dir|
+          dir.add_to_load_path = false
+        end
       end
     end
 

--- a/spec/unit/container/hooks_spec.rb
+++ b/spec/unit/container/hooks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dry::System::Container do
         register(:test, true)
       end
 
-      system.configure {}
+      system.configured!
 
       expect(system[:test]).to be(true)
     end
@@ -27,7 +27,7 @@ RSpec.describe Dry::System::Container do
         end
       end
 
-      descendant.configure {}
+      descendant.configured!
 
       expect(descendant[:test_1]).to be(true)
       expect(descendant[:test_2]).to be(true)

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe Dry::System::Container, ".import" do
   describe "import module" do
     it "loads system when it was not loaded in the imported container yet" do
       class Test::Other < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/import_test").realpath
           config.component_dirs.add "lib"
         end
       end
 
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/test").realpath
           config.component_dirs.add "lib"
         end

--- a/spec/unit/container/load_path_spec.rb
+++ b/spec/unit/container/load_path_spec.rb
@@ -5,8 +5,10 @@ require "dry/system/container"
 RSpec.describe Dry::System::Container, "Load path handling" do
   let(:container) {
     class Test::Container < Dry::System::Container
-      config.root = SPEC_ROOT.join("fixtures/test")
-      config.component_dirs.add "lib"
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures/test")
+        config.component_dirs.add "lib"
+      end
     end
 
     Test::Container

--- a/spec/unit/container/monitor_spec.rb
+++ b/spec/unit/container/monitor_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Dry::System::Container do
     end
 
     before do
-      system.configure {}
+      system.configured!
       system.register(:object, klass.new)
     end
 

--- a/spec/unit/container/notifications_spec.rb
+++ b/spec/unit/container/notifications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dry::System::Container do
 
   describe ".notifications" do
     it "returns configured notifications" do
-      system.configure {}
+      system.configured!
 
       expect(system[:notifications]).to be_instance_of(Dry::Monitor::Notifications)
     end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dry::System::Container do
   context "with default core dir" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/test").realpath
           config.component_dirs.add "lib"
         end
@@ -39,7 +39,7 @@ RSpec.describe Dry::System::Container do
   describe ".init" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/lazytest").realpath
         end
 
@@ -83,7 +83,7 @@ RSpec.describe Dry::System::Container do
       it_behaves_like "a booted system" do
         before do
           class Test::Container < Dry::System::Container
-            configure do |config|
+            configure! do |config|
               config.root = SPEC_ROOT.join("fixtures/test").realpath
             end
 
@@ -116,7 +116,7 @@ RSpec.describe Dry::System::Container do
 
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/stubbing").realpath
           config.component_dirs.add "lib"
         end
@@ -166,7 +166,7 @@ RSpec.describe Dry::System::Container do
       end
 
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/test").realpath
           config.component_dirs.add "lib"
         end
@@ -192,7 +192,7 @@ RSpec.describe Dry::System::Container do
   describe ".resolve" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/test").realpath
           config.component_dirs.add "lib"
         end
@@ -207,7 +207,7 @@ RSpec.describe Dry::System::Container do
   describe ".registered?" do
     before do
       class Test::Container < Dry::System::Container
-        configure do |config|
+        configure! do |config|
           config.root = SPEC_ROOT.join("fixtures/test").realpath
           config.component_dirs.add "lib"
         end


### PR DESCRIPTION
Update all usages of dry-configurable-provided `config` so that any changes are made inside `configure` blocks.

This prepares for the changes in https://github.com/dry-rb/dry-configurable/pull/140.

This involves some specific tweaks to how to `Dry::System::Container` manages its config:

- Since `.configure` is now the only way to update config, we can no longer keep our override `configure that immediately finalizes the config, since we still need to be able to configure the container (e.g. in plugins) without finalising the config at the same time
- For the cases where we _do_ want to configure and finalise config, we provide a new `.configure!` method to do this. This feels pretty good in working practice since it kind of matches the existing `.configured!` and `.finalize!` methods

This was the most involved of all the dry-configurable upgrades so far.

It even necessitated a few changes to the open dry-configurable PR at https://github.com/dry-rb/dry-configurable/pull/140, which I'll write about over in that PR in the next day or so. This is a good thing, though, it hopefully means that PR can be as widely compatible as possible.