### PR TITLE
Update for dry-configurable settings separation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
+gem "dry-configurable", github: "dry-rb/dry-configurable"
+
 # Remove verson constraint once latter versions release their -java packages
 gem "bootsnap", "= 1.4.9"
 gem "dotenv"

--- a/dry-system.gemspec
+++ b/dry-system.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-auto_inject", ">= 0.4.0"
   spec.add_runtime_dependency "dry-configurable", "~> 0.14", ">= 0.14.0"
   spec.add_runtime_dependency "dry-container", "~> 0.9", ">= 0.9.0"
-  spec.add_runtime_dependency "dry-core", ">= 0.9"
+  spec.add_runtime_dependency "dry-core", "~> 0.5", ">= 0.5"
   spec.add_runtime_dependency "dry-inflector", "~> 0.1", ">= 0.1.2"
 
   spec.add_development_dependency "bundler"

--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -247,30 +247,6 @@ module Dry
           !!config.auto_register
         end
 
-        # Returns true if the given setting has been explicitly configured by the user
-        #
-        # This is used when determining whether to apply system-wide default values to a
-        # component dir (explicitly configured settings will not be overridden by
-        # defaults)
-        #
-        # @param key [Symbol] the setting name
-        #
-        # @return [Boolean]
-        #
-        # @see Dry::System::Config::ComponentDirs#apply_defaults_to_dir
-        # @api private
-        def configured?(key)
-          case key
-          when :namespaces
-            # Because we mutate the default value for the `namespaces` setting, rather
-            # than assign a new one, to check if it's configured we must see whether any
-            # namespaces have been added
-            !config.namespaces.empty?
-          else
-            config._settings[key].input_defined?
-          end
-        end
-
         private
 
         def method_missing(name, *args, &block)

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/core/deprecations"
+require "dry/core/equalizer"
 require "dry/system/errors"
 require_relative "namespace"
 
@@ -13,6 +14,8 @@ module Dry
       #
       # @api private
       class Namespaces
+        include Dry::Equalizer(:namespaces)
+
         # @api private
         attr_reader :namespaces
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -86,8 +86,7 @@ module Dry
       setting :provider_registrar, default: Dry::System::ProviderRegistrar
       setting :importer, default: Dry::System::Importer
 
-      # We presume "." as key namespace separator. This is not intended to be
-      # user-configurable.
+      # Expect "." as key namespace separator. This is not intended to be user-configurable.
       config.namespace_separator = KEY_SEPARATOR
 
       class << self

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -156,11 +156,18 @@ module Dry
           return self if configured?
 
           hooks[:after_configure].each { |hook| instance_eval(&hook) }
-          config.finalize! if finalize_config
+
+          _configurable_finalize! if finalize_config
+
           @__configured__ = true
 
           self
         end
+
+        # Finalizes the config for this container
+        #
+        # @api private
+        alias_method :_configurable_finalize!, :finalize!
 
         def configured?
           @__configured__.equal?(true)

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -126,14 +126,7 @@ module Dry
         # @api public
         def configure(finalize_config: true, &block)
           super(&block)
-
-          unless configured?
-            hooks[:after_configure].each { |hook| instance_eval(&hook) }
-            config.finalize! if finalize_config
-            @__configured__ = true
-          end
-
-          self
+          configured!(finalize_config: finalize_config)
         end
 
         # Marks the container as configured, runs the after-`configured` hooks, then


### PR DESCRIPTION
The main change here is that we stop relying on `Dry::Configurable::Config` internal implementation details by using the new `#configured?` API introduced in https://github.com/dry-rb/dry-configurable/pull/143.

While we're here, we make one other small tweak to improve dry-configurable compatibility: use dry-configurable's class-level `#finalize` instead of `Config#finalize` directly, which will mean that we'll continue to have correct behaviour if dry-configurable ever moves any additional logic to this class-level method.