### PR TITLE
Use main dry/monitor entrypoint for autoloading

### DIFF
--- a/lib/dry/system/plugins/notifications.rb
+++ b/lib/dry/system/plugins/notifications.rb
@@ -12,7 +12,7 @@ module Dry
 
         # @api private
         def self.dependencies
-          {"dry-monitor": "dry/monitor/notifications"}
+          {"dry-monitor": "dry/monitor"}
         end
 
         # @api private


### PR DESCRIPTION
Without this change, we were getting errors like this when loading the notifications plugin:

```
NameError:
       uninitialized constant Dry::Monitor::Clock
```