### PR TITLE
Allow env variable prefix and setting namespace to be configured in settings provider

### DIFF
--- a/docsite/source/settings.html.md
+++ b/docsite/source/settings.html.md
@@ -19,6 +19,10 @@ Application.register_provider(:settings, from: :dry_system) do
     require "your/types/module"
   end
 
+  configure do |config|
+    config.prefix = 'SOME_PREFIX_'
+  end
+
   settings do
     setting :database_url, constructor: Types::String.constrained(filled: true)
 
@@ -29,7 +33,7 @@ Application.register_provider(:settings, from: :dry_system) do
 end
 ```
 
-Your provider will then map `ENV` variables to a struct object giving access to your settings as their own methods, which you can use throughout your application:
+An optional prefix can be specified with the `config.prefix` setting inside a `configure` block. Your provider will then map `ENV` variables with the given prefix to a struct object giving access to your settings as their own methods, which you can use throughout your application:
 
 ```ruby
 Application[:settings].database_url # => "postgres://..."
@@ -64,4 +68,57 @@ Or as an injected dependency in your classes:
     end
   end
 end
+```
+
+## Multiple Settings Providers
+
+In some situations you may wish to have multiple settings providers registered to different namespaces, e.g `config.database` and `config.api`. This can be achieved using the `register_as` configuration option:
+
+```ruby
+# system/providers/database_settings.rb:
+
+require "dry/system/provider_sources"
+
+Application.register_provider(:database_settings, from: :dry_system, source: :settings) do
+  before :prepare do
+    require "your/types/module"
+  end
+
+  configure do |config|
+    config.register_as = 'config.database'
+  end
+
+  settings do
+    setting :url, constructor: Types::String.constrained(filled: true)
+  end
+end
+```
+
+```ruby
+# system/providers/api_settings.rb:
+
+require "dry/system/provider_sources"
+
+Application.register_provider(:api_settings, from: :dry_system, source: :settings) do
+  before :prepare do
+    require "your/types/module"
+  end
+
+  configure do |config|
+    config.register_as = 'config.api'
+  end
+
+  settings do
+    setting :base_url, constructor: Types::String.constrained(filled: true)
+  end
+end
+```
+
+The individual settings namespaces can then be accessed from the container seperately:
+
+```ruby
+Application.start(:database_settings)
+Application.start(:api_settings)
+Application['config.database'].url # => "postgres://..."
+Application['config.api'].base_url # => "https://..."
 ```

--- a/lib/dry/system/provider_sources/settings.rb
+++ b/lib/dry/system/provider_sources/settings.rb
@@ -6,13 +6,17 @@ module Dry
       module Settings
         class Source < Dry::System::Provider::Source
           setting :store
+          setting :register_as, default: :settings
+          setting :prefix, default: ""
 
           def prepare
             require "dry/system/provider_sources/settings/config"
           end
 
           def start
-            register(:settings, settings.load(root: target.root, env: target.config.env))
+            register(config.register_as,
+                     settings.load(root: target.root, env: target.config.env,
+                                   prefix: config.prefix))
           end
 
           def settings(&block)

--- a/lib/dry/system/provider_sources/settings/config.rb
+++ b/lib/dry/system/provider_sources/settings/config.rb
@@ -27,14 +27,14 @@ module Dry
         # @api private
         class Config
           # @api private
-          def self.load(root:, env:, loader: Loader)
+          def self.load(root:, env:, prefix: "", loader: Loader)
             loader = loader.new(root: root, env: env)
 
             new.tap do |settings_obj|
               errors = {}
 
               settings.to_a.each do |setting|
-                value = loader[setting.name.to_s.upcase]
+                value = loader[prefix + setting.name.to_s.upcase]
 
                 begin
                   if value


### PR DESCRIPTION
Closes https://github.com/dry-rb/dry-system/issues/253

This PR adds 2 new configuration options to the settings provider source:

1. `prefix`: sets the prefix of the environment variables that will be read. E.g with a prefix of `APP1_` and a setting named `log_level`, the settings provider will look for an environment variable named `APP1_LOG_LEVEL`.

2. `register_as`: sets the namespace that the setting will be registered to. This enables settings objects to be organised according to their purpose e.g `Container['app.config.database']` and also allows multiple settings providers to be registered.

Update: rebased to latest `main`