### PR TITLE
Remove usage of the private Zeitwerk::Registry.loaders

### DIFF
--- a/spec/support/zeitwerk_helpers.rb
+++ b/spec/support/zeitwerk_helpers.rb
@@ -2,17 +2,9 @@
 
 module ZeitwerkHelpers
   def teardown_zeitwerk
-    # From zeitwerk's own test/support/loader_test
-    # adjusted to work with dry-rb gem loaders
-
-    Zeitwerk::Registry.loaders.reject! do |loader|
-      test_loader = loader.dirs.any? { |dir| dir.include?("/spec/") || dir.include?(Dir.tmpdir) }
-
-      if test_loader
+    ObjectSpace.each_object(Zeitwerk::Loader) do |loader|
+      if loader.dirs.any? { |dir| dir.include?("/spec/") || dir.include?(Dir.tmpdir) }
         loader.unregister
-        true
-      else
-        false
       end
     end
   end


### PR DESCRIPTION
`Zeitwerk::Registry` is a private module. This is the place where Zeitwerk internally stores state that is global. For example, given this file to be required, is it managed by any loader? If yes, which one? This is all internal.

The private method `Zeitwerk::Registry.loaders` is going to disappear, and I'd like to volunteer this patch so that your test suite continues being green when it ships.

By design, Zeitwerk hides the loaders. That is, the library does not provide interface to reach that collection, and that is deliberate. If I am a gem author and I load my code with a loader, I am the only one in the entire process owning this thing. Accessing that loader from outside is not something that should be normalized by the API.

I am not saying this is going to be my design guideline forever, but changing this would be done with extra care and a clear use case that justifies it, if that ever happens. And, in any case, at most you'd get a frozen clone of the collection, never a pointer.

For frameworks or situations in which multiple pieces work together and their loaders are known to each other, you can always formalize that. Rails, for example, has two loaders, they are known, and they are public interface. In a more generic situation, if a framework has a variable collection, those loaders would register using framework API, and now that collection is yours and the design reflects it.

In the discouraged case in which you want to iterate over all loaders in memory, Ruby has builtin support in `ObjectSpace.each_object`, let's just use that. Do you want all loaders in RAM? There you have them, it is your responsibility to use that in a responsible way. This is ugly, but that is the price one pays for doing something discouraged, there's some vinegar in it.

Closes #259.