### PR TITLE
Only use DidYouMean-integrated Error for Component loading failure

### DIFF
--- a/lib/dry/system/loader.rb
+++ b/lib/dry/system/loader.rb
@@ -66,7 +66,12 @@ module Dry
           const_name = inflector.camelize(component.const_path)
           inflector.constantize(const_name)
         rescue NameError => e
-          raise ComponentNotLoadableError.new(component, e)
+          # Ensure it's this component's constant, not any other NameError within the component
+          if e.message =~ /#{const_name}( |\n)/
+            raise ComponentNotLoadableError.new(component, e)
+          else
+            raise e
+          end
         end
 
         private

--- a/spec/fixtures/components_with_errors/test/constant_error.rb
+++ b/spec/fixtures/components_with_errors/test/constant_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ConstantError
+  const_get(:NotHere)
+end

--- a/spec/integration/did_you_mean_integration_spec.rb
+++ b/spec/integration/did_you_mean_integration_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "ostruct"
+
+RSpec.describe "DidYouMean integration" do
+  subject(:system) { Test::Container }
+
+  context "with a file with a syntax error in it" do
+    before do
+      class Test::Container < Dry::System::Container
+        use :zeitwerk
+
+        configure do |config|
+          config.root = SPEC_ROOT.join("fixtures").join("components_with_errors").realpath
+          config.component_dirs.add "test"
+        end
+      end
+    end
+
+    it "auto-boots dependency of a bootable component" do
+      expect { system["constant_error"] }
+        .to raise_error(NameError, "uninitialized constant ConstantError::NotHere")
+    end
+  end
+end


### PR DESCRIPTION
Without this, *any* NameError (including NoMethodError) will go through the DidYouMean integration and
it will fail since that code expects only a Constant, not any name (including "undefined local variable or method")

Instead, this code will ensure we only try to do that when we get a NameError for specifically trying to load the constant we're looking for. Everything else will be re-raised and go through the normal flow (including any more DidYouMean default behavior).

Fixes hanami/hanami#1252. (Specifically see [this comment](https://github.com/hanami/hanami/issues/1252#issuecomment-1315898878))

Bug introduced in #217

Thoughts on whether we should test this? We could create a fixture file to load a component that has a NameError in it and ensure that error passes through instead of getting created as a `ComponentNotLoadableError`... but that would error out anyway. Creating a NameError in the spec just raises that before we can even get to the example.

I manually confirmed that it works with [the repo @katafrakt created to illustrate the bug](https://github.com/hanami/hanami/issues/1252#issue-1447575377).