### PR TITLE
Fix a leftover `init` -> `prepare` code sample

### DIFF
--- a/docsite/source/providers.html.md
+++ b/docsite/source/providers.html.md
@@ -77,7 +77,7 @@ You can start one provider as a dependency of another by invoking the providerâ€
 ``` ruby
 # system/providers/logger.rb
 Application.register_provider(:logger) do
-  init do
+  prepare do
     require "logger"
   end
 


### PR DESCRIPTION
An old code example with `init` syntax is still present in the docs.