### PR TITLE
Fix Bootsnap to work with Ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,9 @@ eval_gemfile "Gemfile.devtools"
 gemspec
 
 # Remove verson constraint once latter versions release their -java packages
-gem "bootsnap", "= 1.4.9"
+gem "bootsnap", "= 1.16.0"
 gem "dotenv"
 gem "dry-types"
 gem "dry-events"
 gem "dry-monitor"
 gem "zeitwerk"
-

--- a/lib/dry/system/plugins/bootsnap.rb
+++ b/lib/dry/system/plugins/bootsnap.rb
@@ -32,12 +32,12 @@ module Dry
         def setup_bootsnap
           return unless bootsnap_available?
 
-          ::Bootsnap.setup(config.bootsnap.merge(cache_dir: root.join("tmp/cache").to_s))
+          ::Bootsnap.setup(**config.bootsnap.merge(cache_dir: root.join("tmp/cache").to_s))
         end
 
         # @api private
         def bootsnap_available?
-          RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.3.0" && RUBY_VERSION < "3.1.0"
+          RUBY_ENGINE == "ruby" && RUBY_VERSION >= "3.0.0" && RUBY_VERSION < "3.1.0"
         end
       end
     end

--- a/lib/dry/system/plugins/bootsnap.rb
+++ b/lib/dry/system/plugins/bootsnap.rb
@@ -5,11 +5,9 @@ module Dry
     module Plugins
       module Bootsnap
         DEFAULT_OPTIONS = {
-          load_path_cache: true,
-          disable_trace: true,
+          load_path_cache: false,
           compile_cache_iseq: true,
           compile_cache_yaml: true,
-          autoload_paths_cache: false
         }.freeze
 
         # @api private
@@ -37,7 +35,7 @@ module Dry
 
         # @api private
         def bootsnap_available?
-          RUBY_ENGINE == "ruby" && RUBY_VERSION >= "3.0.0" && RUBY_VERSION < "3.1.0"
+          RUBY_ENGINE == "ruby" && RUBY_VERSION >= "3.0.0"
         end
       end
     end

--- a/spec/integration/container/plugins/bootsnap_spec.rb
+++ b/spec/integration/container/plugins/bootsnap_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Plugins / Bootsnap" do
   end
 
   describe ".require_from_root" do
-    xit "loads file" do
+    it "loads file" do
       system.require_from_root("lib/test/models")
 
       expect(Object.const_defined?("Test::Models")).to be(true)


### PR DESCRIPTION
Due to the changes in keyword arguments for Ruby 3.0 I believe the bootsnap integration stopped working.
This PR updates the `Bootsnap.setup` method call to use `**` operator and get around the initialization issue.
Since dry-system requires ruby 3.0 or higher I've updated the condition to check if bootsnap was available.
Also uncommented a test for bootsnap. I've added an empty file to get the test working but I'm open to other suggestions

Stacktrace from an example repo I created to show the issue
https://github.com/RicardoTrindade/Bootsnap-example
```
Users/ricardot/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/bootsnap-1.15.0/lib/bootsnap.rb:38:in `setup': wrong number of arguments (given 1, expected 0; required keyword: cache_dir) (ArgumentError)
	from /Users/ricardot/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/dry-system-1.0.1/lib/dry/system/plugins/bootsnap.rb:35:in `setup_bootsnap'
	from /Users/ricardot/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/dry-system-1.0.1/lib/dry/system/container.rb:129:in `instance_eval'
	from /Users/ricardot/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/dry-system-1.0.1/lib/dry/system/container.rb:129:in `block in configured!'
	from /Users/ricardot/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/dry-system-1.0.1/lib/dry/system/container.rb:129:in `each'
	from /Users/ricardot/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/dry-system-1.0.1/lib/dry/system/container.rb:129:in `configured!'
	from /Users/ricardot/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/dry-system-1.0.1/lib/dry/system/container.rb:108:in `configure'
	from /Users/ricardot/Documents/github/forks/Bootsnap-example/lib/app.rb:10:in `<class:App>'
	from /Users/ricardot/Documents/github/forks/Bootsnap-example/lib/app.rb:5:in `<top (required)>'
	from /Users/ricardot/Documents/github/forks/Bootsnap-example/config.ru:6:in `require_relative'
	from /Users/ricardot/Documents/github/forks/Bootsnap-example/config.ru:6:in `block in <main>'

```