### PR TITLE
Update docs example of Dry::System.register_provider_sources

### DIFF
--- a/docsite/source/external-provider-sources.html.md
+++ b/docsite/source/external-provider-sources.html.md
@@ -14,7 +14,7 @@ To distribute a group of provider sources (defined in their own files), register
 # my_gem
 #  |- lib/my_gem/provider_sources.rb
 
-Dry::System.register_provider_sources(:common, boot_path: File.join(__dir__, "provider_sources"))
+Dry::System.register_provider_sources(File.join(__dir__, "provider_sources"))
 ```
 
 Then, define your provider source:


### PR DESCRIPTION
Current [docs example](https://dry-rb.org/gems/dry-system/1.0/external-provider-sources/)

```ruby
# my_gem
#  |- lib/my_gem/provider_sources.rb

Dry::System.register_provider_sources(:common, boot_path: File.join(__dir__, "provider_sources"))
```

[Method definition](https://github.com/dry-rb/dry-system/blob/a4ef6decf230c4c0adf81fb61ee7c47e17bf0a93/lib/dry/system.rb#L26)

```ruby
    # Registers the provider sources in the files under the given path
    #
    # @api public
    def self.register_provider_sources(path)
      provider_sources.load_sources(path)
    end
```

### Changes
Updated docs to match method definition