### PR TITLE
Use bootsnap's gemspec to determine availability

### DIFF
--- a/lib/dry/system/plugins/bootsnap.rb
+++ b/lib/dry/system/plugins/bootsnap.rb
@@ -37,7 +37,11 @@ module Dry
 
         # @api private
         def bootsnap_available?
-          RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.3.0" && RUBY_VERSION < "3.1.0"
+          spec = Gem.loaded_specs["bootsnap"] or return false
+
+          RUBY_ENGINE == "ruby" &&
+            spec.match_platform(RUBY_PLATFORM) &&
+            spec.required_ruby_version.satisfied_by?(Gem::Version.new(RUBY_VERSION))
         end
       end
     end


### PR DESCRIPTION
Bootsnap has since dropped support for < 2.6.0, and supports up to 3.2

Use the actual Gem::Specification so this isn't hard-coded.

I believe this is a more future-proof approach than #264 