### PR TITLE
Load providers when accessing via `ProviderRegistrar#[]`

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -608,14 +608,14 @@ module Dry
         def load_component(key)
           return self if registered?(key)
 
-          if (provider = providers.find_and_load_provider(key))
+          if (provider = providers[key])
             provider.start
             return self
           end
 
           component = find_component(key)
 
-          providers.start_provider_dependency(component)
+          providers[component.root_key]&.start
           return self if registered?(key)
 
           if component.loadable?

--- a/lib/dry/system/provider_registrar.rb
+++ b/lib/dry/system/provider_registrar.rb
@@ -84,43 +84,28 @@ module Dry
 
       # rubocop:enable Metrics/PerceivedComplexity
 
-      # Returns a provider for the given name, if it has already been loaded
-      #
-      # @api public
-      def [](provider_name)
-        providers[provider_name]
-      end
-      alias_method :provider, :[]
-
-      # @api private
-      def key?(provider_name)
-        providers.key?(provider_name)
-      end
-
       # Returns a provider if it can be found or loaded, otherwise nil
       #
       # @return [Dry::System::Provider, nil]
       #
-      # @api private
-      def find_and_load_provider(name)
-        name = name.to_sym
+      # @api public
+      def [](provider_name)
+        provider_name = provider_name.to_sym
 
-        if (provider = providers[name])
+        if (provider = providers[provider_name])
           return provider
         end
 
         return if finalized?
 
-        require_provider_file(name)
+        require_provider_file(provider_name)
 
-        providers[name]
+        providers[provider_name]
       end
 
       # @api private
-      def start_provider_dependency(component)
-        if (provider = find_and_load_provider(component.root_key))
-          provider.start
-        end
+      def key?(provider_name)
+        providers.key?(provider_name)
       end
 
       # Returns all provider files within the configured provider_paths.


### PR DESCRIPTION
Move the logic from `ProviderRegistrar#find_and_load_provider` straght into `#[]` for a more convenient and reliable experience when interacting with providers.

Having `#[]` either return a provider or nil without attempting to _load_ the provider was a potential source of confusion. Now it can work as the one and only interface for fetching a provider.

Remove the `#provider` alias for `#[]` since this was private and unused (and unnecessary).

Remove `#start_provider_dependency` (which was the only thing in `ProviderRegistrar` dealing with components instead of providers and instead invoke its internal logic (a one-liner, anyway!) directly in `Container#load_component`.