### PR TITLE
Make Container hooks more useful for dynamic registration

### DIFF
--- a/docsite/source/container.html.md
+++ b/docsite/source/container.html.md
@@ -2,6 +2,8 @@
 title: Container
 layout: gem-single
 name: dry-system
+sections:
+  - hooks
 ---
 
 The main API of dry-system is the abstract container that you inherit from. It allows you to configure basic settings and exposes APIs for requiring files easily. Container is the entry point to your application, and it encapsulates application's state.

--- a/docsite/source/container/hooks.html.md
+++ b/docsite/source/container/hooks.html.md
@@ -1,0 +1,78 @@
+---
+title: Hooks
+layout: gem-single
+name: dry-system
+---
+
+There are a few lifecycle events that you can hook into if you need to ensure things happen in a particular order.
+
+Hooks are executed within the context of the container instance.
+
+### `configure` Event
+
+You can register a callback to fire after the container is configured, which happens one of three ways:
+
+1. The `configure` method is called on the container
+2. The `configured!` method is called
+3. The `finalize!` method is called when neither of the other two have been
+
+```ruby
+class MyApp::Container < Dry::System::Container
+  after(:configure) do
+    # do something here
+  end
+end
+```
+
+### `register` Event
+
+Most of the time, you will know what keys you are working with ahead of time. But for certain cases you may want to
+react to keys dynamically.
+
+```ruby
+class MyApp::Container < Dry::System::Container
+  use :monitoring
+
+  after(:register) do |key|
+    next unless key.end_with?(".gateway")
+
+    monitor(key) do |event|
+      resolve(:logger).debug(key:, method: event[:method], time: event[:time])
+    end
+  end
+end
+```
+
+Now let's say you register `api_client.gateway` into your container. Your API methods will be automatically monitored
+and their timing measured and logged.
+
+### `finalize` Event
+
+Finalization is the point at which the container is made ready, such as booting a web application.
+
+The following keys are loaded in sequence:
+
+1. Providers
+2. Auto-registered components
+3. Manually-registered components
+4. Container imports
+
+At the conclusion of this process, the container is frozen thus preventing any further changes. This makes the
+`finalize` event quite important: it's the last call before your container will disallow mutation.
+
+Unlike the previous events, you can register before hooks in addition to after hooks.
+
+The after hooks will run immediately prior to the container freeze. This allows you to enumerate the container keys
+while they can still be mutated, such as with `decorate` or `monitor`.
+
+```ruby
+class MyApp::Container < Dry::System::Container
+  before(:finalize) do
+    # Before system boot, no keys registered yet
+  end
+
+  after(:finalize) do
+    # After system boot, all keys registered
+  end
+end
+```

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -325,9 +325,9 @@ module Dry
             [providers, auto_registrar, manifest_registrar, importer].each(&:finalize!)
 
             @__finalized__ = true
-
-            self.freeze if freeze
           end
+
+          self.freeze if freeze
 
           self
         end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -485,6 +485,15 @@ module Dry
         end
 
         # @api public
+        def register(key, *)
+          super
+
+          hooks[:after_register].each { |hook| instance_exec(key, &hook) }
+
+          self
+        end
+
+        # @api public
         def resolve(key)
           load_component(key) unless finalized?
 

--- a/spec/unit/container/hooks/after_hooks_spec.rb
+++ b/spec/unit/container/hooks/after_hooks_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::System::Container do
+  subject(:system) do
+    Class.new(described_class)
+  end
+
+  describe "after_register hook" do
+    it "executes after a new key is registered" do
+      expect { |hook|
+        system.after(:register, &hook)
+        system.register(:foo) { "bar" }
+      }.to yield_with_args(:foo)
+    end
+  end
+end

--- a/spec/unit/container/hooks/after_hooks_spec.rb
+++ b/spec/unit/container/hooks/after_hooks_spec.rb
@@ -12,5 +12,33 @@ RSpec.describe Dry::System::Container do
         system.register(:foo) { "bar" }
       }.to yield_with_args(:foo)
     end
+
+    it "provides the fully-qualified key" do
+      expect { |hook|
+        system.after(:register, &hook)
+        system.namespace :foo do
+          register(:bar) { "baz" }
+        end
+      }.to yield_with_args("foo.bar")
+    end
+  end
+
+  describe "after_finalize hook" do
+    it "executes after finalization" do
+      expect { |hook|
+        system.after(:finalize, &hook)
+        system.finalize!
+      }.to yield_control
+    end
+
+    it "executes before the container is frozen" do
+      is_frozen = nil
+
+      system.after(:finalize) { is_frozen = frozen? }
+      system.finalize!
+
+      expect(is_frozen).to eq false
+      expect(system).to be_frozen
+    end
   end
 end


### PR DESCRIPTION
This is a (long-overdue) followup PR to [our conversation](https://discourse.hanamirb.org/t/newrelic-apm-on-hanami-2/872) related to integrating APM into a Dry-System app.

Also relates to hanami/hanami#1360

**Use Case:** I want to be able to dynamically decorate keys as they are added into the container system in order to perform APM metrics without having to touch every file.

**Use Case:** I want to audit the usage of particular namespaces in the Container using Dry-Monitor decoration, such as producing an audit log of Authorization checks.

In these use-cases, it's important that I want to react to container registration without having knowledge of precisely what keys are being registered. The decorate feature works well when keys are known in advance, but otherwise you have to enumerate the keys in the container after registration.

Enumeration is a problem, because `after_finalize` is called after the container is frozen, which is too late to decorate key values.

This PR makes two changes:
1. Establish an `after_register` hook that fires whenever a key is registered
2. Move `after_finalize` to happen prior to freezing the container.

This allows us to either decorate keys dynamically as they are registered, and to enumerate the container keys before the container is frozen in case we want to make alterations.

Due to the complexity of Container value storage between memoization and callable, I opted not to expose the key value directly; the hook code may choose to call `resolve` if it needs that.