### PR TITLE
Restore find_and_load_provider method as an alias

### DIFF
--- a/lib/dry/system/provider_registrar.rb
+++ b/lib/dry/system/provider_registrar.rb
@@ -103,6 +103,9 @@ module Dry
         providers[provider_name]
       end
 
+      # @api public
+      alias_method :find_and_load_provider, :[]
+
       # @api private
       def key?(provider_name)
         providers.key?(provider_name)


### PR DESCRIPTION
This was used by earlier 2.x versions of Hanami, so usage is out in the wild. We should maintain this method to ensure nothing breaks.