### PR TITLE
Adding back `eager_load:` option in `Container#finalize!`"

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -314,7 +314,7 @@ module Dry
         # @return [self] frozen container
         #
         # @api public
-        def finalize!(freeze: true, &)
+        def finalize!(freeze: true, eager_load: true, &)
           return self if finalized?
 
           configured!
@@ -323,6 +323,8 @@ module Dry
             yield(self) if block_given?
 
             [providers, auto_registrar, manifest_registrar, importer].each(&:finalize!)
+
+            keys.each { resolve(_1) } if eager_load
 
             @__finalized__ = true
 

--- a/spec/integration/container/auto_registration/eager_loading_spec.rb
+++ b/spec/integration/container/auto_registration/eager_loading_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe "Eager loading during finalization" do
+  it "raises error when component cannot be found, due to missing inflection" do
+    class Test::Container < Dry::System::Container
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures").realpath
+
+        config.component_dirs.add "components" do |dir|
+          dir.namespaces.add "test", key: nil
+        end
+      end
+    end
+    expect { Test::Container.finalize! }.to raise_error(Dry::System::ComponentNotLoadableError)
+  end
+
+  it "does not raise error when constant can be found" do
+    class Test::Container < Dry::System::Container
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures").realpath
+
+        config.component_dirs.add "components" do |dir|
+          dir.namespaces.add "test", key: nil
+        end
+
+        config.inflector = Dry::Inflector.new { |i| i.acronym("ABC") }
+      end
+    end
+    expect { Test::Container.finalize! }.to_not raise_error
+  end
+end

--- a/spec/integration/container/auto_registration/memoize_spec.rb
+++ b/spec/integration/container/auto_registration/memoize_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe "Auto-registration / Memoizing components" do
             dir.namespaces.add "test", key: nil
             dir.memoize = true
           end
+
+          config.inflector = Dry::Inflector.new { |i| i.acronym("ABC") }
         end
       end
     end
@@ -52,6 +54,8 @@ RSpec.describe "Auto-registration / Memoizing components" do
               !component.key.match?(/bar/)
             end
           end
+
+          config.inflector = Dry::Inflector.new { |i| i.acronym("ABC") }
         end
       end
     end

--- a/spec/unit/container/configuration_spec.rb
+++ b/spec/unit/container/configuration_spec.rb
@@ -175,5 +175,29 @@ RSpec.describe Dry::System::Container, "configuration phase" do
         .from([])
         .to [:after_configure]
     end
+
+    it "raises error for undefined constant (due to inflector missing acronym)" do
+      expect {
+        container.configure do |config|
+          config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs.add "components" do |dir|
+            dir.namespaces.add "test", key: nil
+          end
+        end
+        container.finalize!
+      }.to raise_error(Dry::System::ComponentNotLoadableError)
+    end
+
+    it "does not raises error for undefined constant when eager_load is false" do
+      expect {
+        container.configure do |config|
+          config.root = SPEC_ROOT.join("fixtures").realpath
+          config.component_dirs.add "components" do |dir|
+            dir.namespaces.add "test", key: nil
+          end
+        end
+        container.finalize!(eager_load: false)
+      }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Reverts dry-rb/dry-system#282, see also https://github.com/dry-rb/dry-system/issues/281 and https://github.com/dry-rb/dry-system/pull/276
