### PR TITLE
ManifestRegistrar uses load instead of require

### DIFF
--- a/lib/dry/system/manifest_registrar.rb
+++ b/lib/dry/system/manifest_registrar.rb
@@ -33,7 +33,7 @@ module Dry
 
       # @api private
       def call(component)
-        require(root.join(config.registrations_dir, component.root_key.to_s))
+        load(root.join(config.registrations_dir, "#{component.root_key}#{RB_EXT}"))
       end
 
       # @api private

--- a/spec/integration/container/lazy_loading/manifest_registration_spec.rb
+++ b/spec/integration/container/lazy_loading/manifest_registration_spec.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe "Lazy-loading registration manifest files" do
-  before do
-    module Test
-      class Container < Dry::System::Container
-        configure do |config|
-          config.root = SPEC_ROOT.join("fixtures/manifest_registration").realpath
-        end
+  module Test; end
 
-        add_to_load_path!("lib")
+  def build_container
+    Class.new(Dry::System::Container) do
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures/manifest_registration").realpath
       end
     end
   end
 
   shared_examples "manifest component" do
+    before do
+      Test::Container = build_container
+      Test::Container.add_to_load_path!("lib")
+    end
+
     it "loads a registration manifest file if the component could not be found" do
       expect(Test::Container["foo.special"]).to be_a(Test::Foo)
       expect(Test::Container["foo.special"].name).to eq "special"
@@ -25,7 +28,36 @@ RSpec.describe "Lazy-loading registration manifest files" do
   end
 
   context "Finalized container" do
-    before { Test::Container.finalize! }
     include_examples "manifest component"
+    before { Test::Container.finalize! }
+  end
+
+  context "Autoloaded container" do
+    let :autoloader do
+      Zeitwerk::Loader.new.tap do |loader|
+        loader.enable_reloading
+
+        # This is a simulacrum of the Dry::Rails container reset
+        # that happens on every reload
+        loader.on_setup do
+          if Test.const_defined?(:Container)
+            Test.__send__(:remove_const, :Container)
+          end
+
+          Test.const_set :Container, build_container
+          Test::Container.finalize!
+
+          loader.push_dir(Test::Container.root)
+        end
+      end
+    end
+
+    it "reloads manifest keys" do
+      autoloader.setup
+      expect(Test::Container.keys).to include("foo.special")
+
+      autoloader.reload
+      expect(Test::Container.keys).to include("foo.special")
+    end
   end
 end


### PR DESCRIPTION
This is a bug that is caused by the interaction between dry-system and dry-rails.

Dry::Rails rebuilds the Container from scratch on every reload, which resets all the keys. Since ManifestRegistrar was using `require`, this reload would not register the keys as expected.