### PR TITLE
Fix lazy loading of imported components

### DIFF
--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -629,8 +629,8 @@ module Dry
             load_local_component(component)
           elsif manifest_registrar.file_exists?(component)
             manifest_registrar.(component)
-          elsif importer.namespace?(component.root_key&.to_s)
-            load_imported_component(component.identifier, namespace: component.root_key&.to_s)
+          elsif importer.namespace?(component.root_key)
+            load_imported_component(component.identifier, namespace: component.root_key)
           elsif importer.namespace?(nil)
             load_imported_component(component.identifier, namespace: nil)
           end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -629,8 +629,8 @@ module Dry
             load_local_component(component)
           elsif manifest_registrar.file_exists?(component)
             manifest_registrar.(component)
-          elsif importer.namespace?(component.root_key)
-            load_imported_component(component.identifier, namespace: component.root_key)
+          elsif importer.namespace?(component.root_key&.to_s)
+            load_imported_component(component.identifier, namespace: component.root_key&.to_s)
           elsif importer.namespace?(nil)
             load_imported_component(component.identifier, namespace: nil)
           end

--- a/lib/dry/system/importer.rb
+++ b/lib/dry/system/importer.rb
@@ -36,7 +36,7 @@ module Dry
 
       # @api private
       def register(namespace:, container:, keys: nil)
-        registry[namespace] = Item.new(
+        registry[namespace_key(namespace)] = Item.new(
           namespace: namespace,
           container: container,
           import_keys: keys
@@ -45,12 +45,12 @@ module Dry
 
       # @api private
       def [](name)
-        registry.fetch(name)
+        registry.fetch(namespace_key(name))
       end
 
       # @api private
       def key?(name)
-        registry.key?(name)
+        registry.key?(namespace_key(name))
       end
       alias_method :namespace?, :key?
 
@@ -75,6 +75,17 @@ module Dry
       end
 
       private
+
+      # Returns nil if given a nil (i.e. root) namespace. Otherwise, converts the namespace to a
+      # string.
+      #
+      # This ensures imported components are found when either symbols or strings to given as the
+      # namespace in {Container.import}.
+      def namespace_key(namespace)
+        return nil if namespace.nil?
+
+        namespace.to_s
+      end
 
       def keys_to_import(keys, item)
         keys


### PR DESCRIPTION
We were checking for an import namespace using a component `root_key`, which is a symbol, whereas the importer was expecting strings. This led to imported components only becoming available on a full boot, not when lazy loading properly (because the check for their namespace in the importer would always return false due to the type mismatch).

This will resolve https://github.com/hanami/hanami/issues/1529.