### PR TITLE
ManifestRegistrar#finalize! avoids duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid errors from attempted duplicate registrations when finalizing a container with manifest-registered dependencies that have already been loaded as part of finalizing providers. (@alassek, @timriley in #295)
+
 [Unreleased]: https://github.com/dry-rb/dry-system/compare/v1.2.5...main
 
 ## [1.2.5] - 2025-12-01

--- a/lib/dry/system/manifest_registrar.rb
+++ b/lib/dry/system/manifest_registrar.rb
@@ -32,7 +32,7 @@ module Dry
 
           # Skip files already loaded during earlier stages of finalization, such as a provider
           # resolving a component satisfied via a manifest. Since `#call` uses `load`, re-running
-          # here would duplicate registrations.
+          # here would attempt a duplicate registration and raise an error.
           call(ident) unless @loaded.include?(ident.root_key)
         end
       end

--- a/lib/dry/system/manifest_registrar.rb
+++ b/lib/dry/system/manifest_registrar.rb
@@ -26,8 +26,13 @@ module Dry
 
       # @api private
       def finalize!
+        eager_loaded = container.keys.each_with_object(Set.new) do |key, set|
+          set << Identifier.new(key).root_key
+        end
+
         ::Dir[registrations_dir.join(RB_GLOB)].each do |file|
-          call(Identifier.new(File.basename(file, RB_EXT)))
+          ident = Identifier.new(File.basename(file, RB_EXT))
+          call(ident) unless eager_loaded.include?(ident.root_key)
         end
       end
 

--- a/lib/dry/system/manifest_registrar.rb
+++ b/lib/dry/system/manifest_registrar.rb
@@ -22,22 +22,24 @@ module Dry
       def initialize(container)
         @container = container
         @config = container.config
+        @loaded = Set.new
       end
 
       # @api private
       def finalize!
-        eager_loaded = container.keys.each_with_object(Set.new) do |key, set|
-          set << Identifier.new(key).root_key
-        end
-
         ::Dir[registrations_dir.join(RB_GLOB)].each do |file|
           ident = Identifier.new(File.basename(file, RB_EXT))
-          call(ident) unless eager_loaded.include?(ident.root_key)
+
+          # Skip files already loaded during earlier stages of finalization, such as a provider
+          # resolving a component satisfied via a manifest. Since `#call` uses `load`, re-running
+          # here would duplicate registrations.
+          call(ident) unless @loaded.include?(ident.root_key)
         end
       end
 
       # @api private
       def call(component)
+        @loaded << component.root_key
         load(root.join(config.registrations_dir, "#{component.root_key}#{RB_EXT}"))
       end
 

--- a/spec/integration/container/providers/eager_loading_manifest_dependency_spec.rb
+++ b/spec/integration/container/providers/eager_loading_manifest_dependency_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe "Providers / Eager-loading a manifest-registered dependency" do
+  before :context do
+    @dir = make_tmp_directory
+
+    with_directory(@dir) do
+      write "system/registrations/deps.rb", <<~RUBY
+        Test::Container.namespace(:deps) do |container|
+          container.register(:thing) { Object.new }
+        end
+      RUBY
+    end
+  end
+
+  before do
+    root = @dir
+    Test::Container = Class.new(Dry::System::Container) do
+      configure do |config|
+        config.root = root
+      end
+
+      register_provider :my_provider do
+        start do
+          target["deps.thing"]
+        end
+      end
+    end
+  end
+
+  it "does not register the manifest dependency more than once" do
+    expect { Test::Container.finalize! }.not_to raise_error
+    expect(Test::Container["deps.thing"]).to be
+  end
+end

--- a/spec/integration/container/providers/lazy_loading_manifest_during_finalize_spec.rb
+++ b/spec/integration/container/providers/lazy_loading_manifest_during_finalize_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Providers / Eager-loading a manifest-registered dependency" do
+RSpec.describe "Providers / Lazy loading a manifest-registered dependency as part of finalize" do
   before :context do
     @dir = make_tmp_directory
 


### PR DESCRIPTION
This resolves a subtlety introduced by the fix in #286

`Container#finalize!` processes providers first, before moving on to manifest registrations.

If a class injects something defined by a manifest file, and this class is instantiated within a provider, this eager-loads the manifest key before `finalize!` reaches the ManifestRegistrar.

Moving `ManifestRegistrar#call` to use `load` instead of `require` introduced the possibility of double-registering a key.