### PR TITLE
Support :root as a root configuration value

### DIFF
--- a/lib/dry/system/config/component_dir.rb
+++ b/lib/dry/system/config/component_dir.rb
@@ -200,7 +200,7 @@ module Dry
         # @api public
         def initialize(path)
           super()
-          @path = path
+          @path = path == ROOT ? EMPTY_STRING : path
           yield self if block_given?
         end
 

--- a/lib/dry/system/config/component_dirs.rb
+++ b/lib/dry/system/config/component_dirs.rb
@@ -112,14 +112,14 @@ module Dry
 
         # Returns and optionally yields a previously added component dir
         #
-        # @param path [String] the path for the component dir
+        # @param path [String, :root] the path for the component dir
         # @yieldparam dir [ComponentDir] the component dir
         #
         # @return [ComponentDir] the component dir
         #
         # @api public
         def dir(path)
-          dirs[path].tap do |dir|
+          dirs[normalize_path(path)].tap do |dir|
             # Defaults can be (re-)applied first, since the dir has already been added
             apply_defaults_to_dir(dir) if dir
             yield dir if block_given?
@@ -130,7 +130,7 @@ module Dry
         # @overload add(path)
         #   Adds and configures a component dir for the given path
         #
-        #   @param path [String] the path for the component dir, relative to the configured
+        #   @param path [String, :root] the path for the component dir, relative to the configured
         #     container root
         #   @yieldparam dir [ComponentDir] the component dir to configure
         #
@@ -166,20 +166,20 @@ module Dry
             # Defaults must be applied after yielding, since the dir is being newly added,
             # and must have its configuration fully in place before we can know which
             # defaults to apply
-            yield dir if path_or_dir == path && block_given?
+            yield dir if !path_or_dir.is_a?(ComponentDir) && block_given?
             apply_defaults_to_dir(dir)
           end
         end
 
         # Deletes and returns a previously added component dir
         #
-        # @param path [String] the path for the component dir
+        # @param path [String, :root] the path for the component dir
         #
         # @return [ComponentDir] the removed component dir
         #
         # @api public
         def delete(path)
-          dirs.delete(path)
+          dirs.delete(normalize_path(path))
         end
 
         # Returns the paths of the component dirs
@@ -248,11 +248,18 @@ module Dry
         def path_and_dir(path_or_dir)
           if path_or_dir.is_a?(ComponentDir)
             dir = path_or_dir
-            [dir.path, dir]
+            [normalize_path(dir.path), dir]
           else
-            path = path_or_dir
+            path = normalize_path(path_or_dir)
             [path, ComponentDir.new(path)]
           end
+        end
+
+        def normalize_path(path)
+          return EMPTY_STRING if path == ROOT
+          return path if path.is_a?(String)
+
+          raise TypeError, "Component dir path must be a String or :root"
         end
 
         # Applies default settings to a component dir. This is run every time the dirs are

--- a/lib/dry/system/config/namespaces.rb
+++ b/lib/dry/system/config/namespaces.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/system/constants"
 require "dry/system/errors"
 
 module Dry
@@ -34,7 +35,7 @@ module Dry
         #
         # @api public
         def namespace(path)
-          namespaces[path]
+          namespaces[path == ROOT ? Namespace::ROOT_PATH : path]
         end
         alias_method :[], :namespace
 
@@ -80,8 +81,8 @@ module Dry
         #
         #   namespaces.add "bananas", key: "desserts", const: "eat_me/now"
         #
-        # @param path [String] the path to the sub-directory of source files to which this
-        #   namespace should apply, relative to the component dir
+        # @param path [String, :root, nil] the path to the sub-directory of source files to
+        #   which this namespace should apply, relative to the component dir
         # @param key [String, nil] the leading namespace to apply to the container keys
         #   for the components. Set `nil` for the keys to be top-level.
         # @param const [String, nil] the Ruby constant namespace to expect for constants
@@ -94,7 +95,11 @@ module Dry
         # @see Namespace
         #
         # @api public
-        def add(path, key: path, const: path)
+        def add(path, key: Undefined, const: Undefined)
+          path = normalize_path(path)
+          key = Undefined.default(key, path)
+          const = Undefined.default(const, path)
+
           raise NamespaceAlreadyAddedError, path if namespaces.key?(path)
 
           namespaces[path] = Namespace.new(path: path, key: key, const: const)
@@ -106,7 +111,7 @@ module Dry
         #
         # @api public
         def add_root(key: nil, const: nil)
-          add(Namespace::ROOT_PATH, key: key, const: const)
+          add(ROOT, key: key, const: const)
         end
 
         # Deletes the configured namespace for the given path and returns the namespace
@@ -119,7 +124,7 @@ module Dry
         #
         # @api public
         def delete(path)
-          namespaces.delete(path)
+          namespaces.delete(path == ROOT ? Namespace::ROOT_PATH : path)
         end
 
         # Deletes the configured root namespace and returns the namespace
@@ -185,6 +190,16 @@ module Dry
         # @api public
         def each(&)
           to_a.each(&)
+        end
+
+        private
+
+        def normalize_path(path)
+          return Namespace::ROOT_PATH if path == ROOT
+          return path if path.nil?
+          return path if path.is_a?(String)
+
+          raise TypeError, "Namespace path must be a String, nil, or :root"
         end
       end
     end

--- a/lib/dry/system/constants.rb
+++ b/lib/dry/system/constants.rb
@@ -9,5 +9,6 @@ module Dry
     PATH_SEPARATOR = File::SEPARATOR
     KEY_SEPARATOR = "."
     WORD_REGEX = /\w+/
+    ROOT = :root
   end
 end

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -169,7 +169,7 @@ module Dry
         #
         # @param keys [Array<String>] Keys for the components to import
         # @param from [Class] The container to import from
-        # @param as [Symbol] Namespace to use for the components of the imported container
+        # @param as [String, Symbol, nil, :root] Namespace to use for the components of the imported container
         #
         # @raise [Dry::System::ContainerAlreadyFinalizedError] if the container has already
         #  been finalized

--- a/lib/dry/system/importer.rb
+++ b/lib/dry/system/importer.rb
@@ -36,6 +36,8 @@ module Dry
 
       # @api private
       def register(namespace:, container:, keys: nil)
+        namespace = normalize_namespace(namespace)
+
         registry[namespace_key(namespace)] = Item.new(
           namespace: namespace,
           container: container,
@@ -75,6 +77,13 @@ module Dry
       end
 
       private
+
+      def normalize_namespace(namespace)
+        return nil if namespace == ROOT
+        return namespace if namespace.nil? || namespace.is_a?(String) || namespace.is_a?(Symbol)
+
+        raise TypeError, "Import namespace must be a String, Symbol, nil, or :root"
+      end
 
       # Returns nil if given a nil (i.e. root) namespace. Otherwise, converts the namespace to a
       # string.

--- a/spec/integration/container/auto_registration_spec.rb
+++ b/spec/integration/container/auto_registration_spec.rb
@@ -4,6 +4,30 @@ require "dry/system/container"
 require "zeitwerk"
 
 RSpec.describe "Auto-registration" do
+  specify "Resolving components from the container root" do
+    root = make_tmp_directory
+
+    with_directory(root) do
+      write "root_component.rb", <<~RUBY
+        module Test
+          class RootComponent
+          end
+        end
+      RUBY
+    end
+
+    container = Class.new(Dry::System::Container) do
+      configure do |config|
+        config.root = root
+        config.component_dirs.add :root do |dir|
+          dir.namespaces.add :root, const: "test"
+        end
+      end
+    end
+
+    expect(container["root_component"]).to be_a Test::RootComponent
+  end
+
   specify "Resolving components from a non-finalized container, without a default namespace" do
     module Test
       class Container < Dry::System::Container

--- a/spec/unit/config/component_dirs_spec.rb
+++ b/spec/unit/config/component_dirs_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe Dry::System::Config::ComponentDirs do
   end
 
   describe "#add" do
+    it "adds the container root" do
+      dir = component_dirs.add(:root)
+
+      expect(dir.path).to eq ""
+      expect(component_dirs.dir(:root)).to be dir
+    end
+
     it "adds a component dir by path, with config set on a yielded dir" do
       expect {
         component_dirs.add "test/path" do |dir|
@@ -117,9 +124,22 @@ RSpec.describe Dry::System::Config::ComponentDirs do
       expect(dir.namespaces.to_a.map(&:path)).to eq [nil]
       expect(dir.memoize).to be false
     end
+
+    it "rejects unsupported path values" do
+      [nil, :other, 123].each do |path|
+        expect { component_dirs.add(path) }
+          .to raise_error(TypeError, "Component dir path must be a String or :root")
+      end
+    end
   end
 
   describe "#delete" do
+    it "deletes the container root" do
+      added_dir = component_dirs.add(:root)
+
+      expect(component_dirs.delete(:root)).to be added_dir
+    end
+
     it "deletes and returns the component dir for the given path" do
       added_dir = component_dirs.add("test/path")
 

--- a/spec/unit/config/namespaces_spec.rb
+++ b/spec/unit/config/namespaces_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Dry::System::Config::Namespaces do
     it "returns nil when no namepace was previously configured for the given path" do
       expect(namespaces.namespace("test/path")).to be nil
     end
+
+    it "returns the root namespace for :root" do
+      added_namespace = namespaces.add(:root)
+
+      expect(namespaces.namespace(:root)).to be added_namespace
+    end
   end
 
   describe "#[]" do
@@ -43,6 +49,20 @@ RSpec.describe Dry::System::Config::Namespaces do
   end
 
   describe "#add" do
+    it "adds a root namespace" do
+      namespace = namespaces.add(:root)
+
+      expect(namespace).to be_root
+      expect(namespace.key).to be_nil
+      expect(namespace.const).to be_nil
+    end
+
+    it "keeps nil as a root path alias" do
+      namespace = namespaces.add(nil)
+
+      expect(namespace).to be_root
+    end
+
     it "adds the namespace with the given configuration" do
       expect {
         namespaces.add "test/path", key: "key_ns", const: "const_ns"
@@ -61,6 +81,13 @@ RSpec.describe Dry::System::Config::Namespaces do
       namespaces.add "test/path"
 
       expect { namespaces.add "test/path" }.to raise_error(Dry::System::NamespaceAlreadyAddedError, %r{test/path})
+    end
+
+    it "rejects unsupported path values" do
+      [:other, 123].each do |path|
+        expect { namespaces.add(path) }
+          .to raise_error(TypeError, "Namespace path must be a String, nil, or :root")
+      end
     end
   end
 

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -21,6 +21,35 @@ RSpec.describe Dry::System::Container, ".import" do
     expect(app["persistence.users"]).to eql(%w[jane joe])
   end
 
+  it "imports into a string namespace" do
+    app.import(from: db, as: "persistence")
+
+    app.finalize!
+
+    expect(app["persistence.users"]).to eql(%w[jane joe])
+  end
+
+  it "imports into the root namespace" do
+    app.import(from: db, as: :root)
+
+    app.finalize!
+
+    expect(app["users"]).to eql(%w[jane joe])
+  end
+
+  it "keeps nil as a root namespace alias" do
+    app.import(from: db, as: nil)
+
+    app.finalize!
+
+    expect(app["users"]).to eql(%w[jane joe])
+  end
+
+  it "rejects unsupported namespace values" do
+    expect { app.import(from: db, as: 123) }
+      .to raise_error(TypeError, "Import namespace must be a String, Symbol, nil, or :root")
+  end
+
   context "when container has been finalized" do
     it "raises an error" do
       app.finalize!


### PR DESCRIPTION
Closes #238.

This adds `:root` support for component directories, component directory namespaces, and container import aliases. Existing empty-string, nil, and symbol forms remain compatible, while unsupported path and alias values now fail early.

Tests:

- `bundle exec rspec spec/unit/config/component_dirs_spec.rb spec/unit/config/namespaces_spec.rb spec/unit/container/import_spec.rb spec/integration/container/auto_registration_spec.rb`
- `bundle exec rspec --exclude-pattern spec/integration/container/plugins/bootsnap_spec.rb`
- `bundle exec rubocop` on the changed Ruby files