### PR TITLE
Enable reloading with zeitwerk and use load for provider file loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Changed
 
+- Provider files are now evaluated with `load` rather than `require`, matching the `ManifestRegistrar`. A provider file is evaluated once per provider registrar rather than once per process, so a second container sharing a provider dir gets its own providers instead of having the file skipped, and a container built afresh picks up changes to it. (@afomera)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- The Zeitwerk plugin accepts an `enable_reloading:` option, which enables reloading on the loader ahead of `setup`, so Zeitwerk tracks the constants it defines and they can be unloaded later. Applied from the plugin's `after(:configure)` hook, so it is in time whether the loader is set up by the plugin or by the integrating library. (@afomera)
+
 ### Changed
 
 - Provider files are now evaluated with `load` rather than `require`, matching the `ManifestRegistrar`. A provider file is evaluated once per provider registrar rather than once per process, so a second container sharing a provider dir gets its own providers instead of having the file skipped, and a container built afresh picks up changes to it. (@afomera)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
-- The Zeitwerk plugin accepts an `enable_reloading:` option, which enables reloading on the loader ahead of `setup`, so Zeitwerk tracks the constants it defines and they can be unloaded later. Applied from the plugin's `after(:configure)` hook, so it is in time whether the loader is set up by the plugin or by the integrating library. (@afomera)
+- The Zeitwerk plugin accepts an `enable_reloading:` option, which enables reloading on the loader ahead of `setup`, so Zeitwerk tracks the constants it defines and they can be unloaded later. Applied from the plugin's `after(:configure)` hook, so it is in time whether the loader is set up by the plugin or by the integrating library. (@afomera in #297)
 
 ### Changed
 
-- Provider files are now evaluated with `load` rather than `require`, matching the `ManifestRegistrar`. A provider file is evaluated once per provider registrar rather than once per process, so a second container sharing a provider dir gets its own providers instead of having the file skipped, and a container built afresh picks up changes to it. (@afomera)
+- Provider files are now evaluated with `load` rather than `require`, matching the `ManifestRegistrar`. A provider file is evaluated once per provider registrar rather than once per process, so a second container sharing a provider dir gets its own providers instead of having the file skipped, and a container built afresh picks up changes to it. (@afomera in #297)
 
 ### Deprecated
 

--- a/lib/dry/system/plugins/zeitwerk.rb
+++ b/lib/dry/system/plugins/zeitwerk.rb
@@ -17,13 +17,15 @@ module Dry
         end
 
         # @api private
-        attr_reader :loader, :run_setup, :eager_load, :debug
+        attr_reader :loader, :run_setup, :eager_load, :enable_reloading, :debug
 
         # @api private
-        def initialize(loader: nil, run_setup: true, eager_load: nil, debug: false)
+        def initialize(loader: nil, run_setup: true, eager_load: nil, enable_reloading: false,
+                       debug: false)
           @loader = loader || ::Zeitwerk::Loader.new
           @run_setup = run_setup
           @eager_load = eager_load
+          @enable_reloading = enable_reloading
           @debug = debug
           super()
         end
@@ -61,6 +63,13 @@ module Dry
         def configure_loader(loader, system)
           loader.tag = system.config.name || system.name unless loader.tag
           loader.inflector = CompatInflector.new(system.config)
+
+          # Zeitwerk only keeps track of the constants it defines (and so can only unload them
+          # later) when reloading is enabled ahead of `setup`. This runs from an `after(:configure)`
+          # hook, so it is in time either way: whether the loader is set up here via `run_setup`, or
+          # by the integrating library afterwards.
+          loader.enable_reloading if enable_reloading
+
           loader.logger = method(:puts) if debug
         end
 

--- a/lib/dry/system/provider_registrar.rb
+++ b/lib/dry/system/provider_registrar.rb
@@ -34,6 +34,7 @@ module Dry
       def initialize(container)
         @providers = {}
         @container = container
+        @loaded = Set.new
       end
 
       # @api private
@@ -270,7 +271,7 @@ module Dry
       def load_provider(path)
         name = Pathname(path).basename(RB_EXT).to_s.to_sym
 
-        Kernel.require path unless providers.key?(name)
+        load_provider_file(path) unless providers.key?(name)
 
         self
       end
@@ -278,7 +279,29 @@ module Dry
       def require_provider_file(name)
         provider_file = find_provider_file(name)
 
-        Kernel.require provider_file if provider_file
+        load_provider_file(provider_file) if provider_file
+      end
+
+      # Evaluates a provider file, at most once for this registrar.
+      #
+      # Uses `load` rather than `require`, matching the {ManifestRegistrar}, so that a provider
+      # file is evaluated once per registrar rather than once per process. Providers register
+      # themselves against a particular container, so a file already `require`d for one container
+      # would otherwise be skipped for the next, leaving that container without the provider.
+      # Evaluating the file again also means a container built afresh picks up any changes to it.
+      #
+      # Files are tracked because `load`, unlike `require`, will happily evaluate one twice. A
+      # provider file registering a provider under some other name is never satisfied by its own
+      # loading, so it would otherwise be evaluated on every lookup of the name matching its
+      # filename, and raise {ProviderAlreadyRegisteredError} the second time around.
+      def load_provider_file(path)
+        path = path.to_s
+
+        return if @loaded.include?(path)
+
+        @loaded << path
+
+        Kernel.load path
       end
 
       def find_provider_file(name)

--- a/spec/integration/container/plugins/zeitwerk/enable_reloading_spec.rb
+++ b/spec/integration/container/plugins/zeitwerk/enable_reloading_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.describe "Zeitwerk plugin / Enabling reloading" do
+  before do
+    allow(Zeitwerk::Loader).to receive(:new).and_return(ZeitwerkLoaderRegistry.new_loader)
+  end
+
+  after { ZeitwerkLoaderRegistry.clear }
+
+  def build_container(tmp_dir, **plugin_options)
+    Class.new(Dry::System::Container) do
+      use :zeitwerk, **plugin_options
+
+      configure do |config|
+        config.root = tmp_dir
+        config.component_dirs.add "lib" do |dir|
+          dir.namespaces.add_root const: "test"
+        end
+      end
+    end
+  end
+
+  it "does not enable reloading by default" do
+    with_tmp_directory do |tmp_dir|
+      write "lib/foo.rb", <<~RUBY
+        module Test
+          class Foo; end
+        end
+      RUBY
+
+      container = build_container(tmp_dir)
+
+      expect(container["foo"]).to be_a Test::Foo
+      expect(container.autoloader.reloading_enabled?).to be false
+      expect(container.autoloader.unloadable_cpaths).to be_empty
+    end
+  end
+
+  it "enables reloading on the loader before it is set up" do
+    with_tmp_directory do |tmp_dir|
+      write "lib/foo.rb", <<~RUBY
+        module Test
+          class Foo; end
+        end
+      RUBY
+
+      container = build_container(tmp_dir, enable_reloading: true)
+
+      expect(container["foo"]).to be_a Test::Foo
+      expect(container.autoloader.reloading_enabled?).to be true
+      expect(container.autoloader.unloadable_cpaths).to include "Test::Foo"
+    end
+  end
+
+  it "enables reloading in time for a loader set up by the integrating library" do
+    with_tmp_directory do |tmp_dir|
+      write "lib/foo.rb", <<~RUBY
+        module Test
+          class Foo; end
+        end
+      RUBY
+
+      container = build_container(tmp_dir, run_setup: false, enable_reloading: true)
+
+      # `run_setup: false` leaves `setup` to the integrating library, which must still find
+      # reloading enabled: Zeitwerk only tracks unloadable constants when told ahead of `setup`.
+      container.autoloader.setup
+
+      expect(container["foo"]).to be_a Test::Foo
+      expect(container.autoloader.reloading_enabled?).to be true
+      expect(container.autoloader.unloadable_cpaths).to include "Test::Foo"
+    end
+  end
+
+  it "allows the loaded constants to be unloaded and reloaded" do
+    with_tmp_directory do |tmp_dir|
+      write "lib/foo.rb", <<~RUBY
+        module Test
+          class Foo
+            def call = "original"
+          end
+        end
+      RUBY
+
+      container = build_container(tmp_dir, enable_reloading: true)
+
+      expect(container["foo"].call).to eq "original"
+
+      File.write(File.join(tmp_dir, "lib", "foo.rb"), <<~RUBY)
+        module Test
+          class Foo
+            def call = "changed"
+          end
+        end
+      RUBY
+
+      container.autoloader.reload
+
+      expect(Test::Foo.new.call).to eq "changed"
+    end
+  end
+end

--- a/spec/integration/container/providers/provider_file_loading_spec.rb
+++ b/spec/integration/container/providers/provider_file_loading_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe "Providers / Loading provider files" do
+  before do
+    module Test
+      class << self
+        attr_accessor :container, :message
+      end
+    end
+
+    Test.message = "hello"
+
+    @dir = make_tmp_directory
+
+    write_provider <<~RUBY
+      Test.container.register_provider(:greeter) do
+        start { register(:greeter, Test.message) }
+      end
+    RUBY
+  end
+
+  def write_provider(content)
+    dir = File.join(@dir, "system", "providers")
+    FileUtils.mkdir_p(dir)
+
+    File.write(File.join(dir, "greeter.rb"), content)
+  end
+
+  def build_container
+    root = @dir
+
+    Class.new(Dry::System::Container) do
+      config.root = root
+    end
+  end
+
+  specify "a provider file is evaluated once per container, not once per process" do
+    Test.container = build_container
+    expect(Test.container[:greeter]).to eq "hello"
+
+    # A second container sharing the provider dir must get its own provider, rather than having
+    # the file skipped because the first container already loaded it.
+    Test.container = build_container
+    expect(Test.container[:greeter]).to eq "hello"
+  end
+
+  specify "a container built afresh picks up changes to a provider file" do
+    Test.container = build_container
+    expect(Test.container[:greeter]).to eq "hello"
+
+    write_provider <<~RUBY
+      Test.container.register_provider(:greeter) do
+        start { register(:greeter, Test.message.upcase) }
+      end
+    RUBY
+
+    Test.container = build_container
+    expect(Test.container[:greeter]).to eq "HELLO"
+  end
+
+  specify "a provider file is evaluated at most once for a given container" do
+    # The provider name does not match the file name, so looking up `:greeter` loads the file
+    # without ever finding the provider it was looking for.
+    write_provider <<~RUBY
+      Test.container.register_provider(:other_name) do
+        start { register(:greeter, Test.message) }
+      end
+    RUBY
+
+    Test.container = build_container
+
+    expect(Test.container.providers[:greeter]).to be_nil
+
+    # Loading the file a second time would re-register `:other_name` and raise.
+    expect { Test.container.providers[:greeter] }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Out of the Updates to bring code reloading in-house with Zeitwerk this PR does two things, I've split them into their own commits in case we wanted to review separately but it wasn't a ton of code together so leaving it so less PRs to review/manage at once. Let me know if you disagree!

- This updates it to load the provider files with `load` rather than require which only executes the file the first time, load makes it reloadable by default
- Add the enable_reloading plugin for zeitwerk 
